### PR TITLE
Fixed issue with insert Embeded Data

### DIFF
--- a/scripts/do.js
+++ b/scripts/do.js
@@ -2080,8 +2080,8 @@ var DO = {
         var scriptType = {
           'meta-turtle': {
             scriptStart: '<script id="meta-turtle" title="Turtle" type="text/turtle">',
-            cdataStart: '# ' + DO.C.CDATAStart + '\n',
-            cdataEnd: '\n# ' + DO.C.CDATAEnd,
+            cdataStart: DO.C.CDATAStart + '\n',
+            cdataEnd: '\n' + DO.C.CDATAEnd,
             scriptEnd: '</script>'
           },
           'meta-json-ld': {
@@ -2092,8 +2092,8 @@ var DO = {
           },
           'meta-trig': {
             scriptStart: '<script id="meta-trig" title="TriG" type="application/trig">',
-            cdataStart: '# ' + DO.C.CDATAStart + '\n',
-            cdataEnd: '\n# ' + DO.C.CDATAEnd,
+            cdataStart: DO.C.CDATAStart + '\n',
+            cdataEnd: '\n' + DO.C.CDATAEnd,
             scriptEnd: '</script>'
           }
         }
@@ -2155,12 +2155,13 @@ var DO = {
             var script = document.getElementById(name);
 
             if (scriptEntry.length > 0) {
-              var scriptContent = '  ' + scriptType[name].scriptStart + scriptType[name].cdataStart + scriptEntry + scriptType[name].cdataEnd + scriptType[name].scriptEnd;
               //If there was a script already
               if (script) {
+                var scriptContent = scriptType[name].cdataStart + scriptEntry + scriptType[name].cdataEnd;
                 script.innerHTML = scriptContent;
               }
               else {
+                var scriptContent = '  ' + scriptType[name].scriptStart + scriptType[name].cdataStart + scriptEntry + scriptType[name].cdataEnd + scriptType[name].scriptEnd;
                 document.querySelector('head').insertAdjacentHTML('beforeend', scriptContent);
               }
             }

--- a/scripts/do.js
+++ b/scripts/do.js
@@ -2080,8 +2080,8 @@ var DO = {
         var scriptType = {
           'meta-turtle': {
             scriptStart: '<script id="meta-turtle" title="Turtle" type="text/turtle">',
-            cdataStart: DO.C.CDATAStart + '\n',
-            cdataEnd: '\n' + DO.C.CDATAEnd,
+            cdataStart: '# ' + DO.C.CDATAStart + '\n',
+            cdataEnd: '\n#' + DO.C.CDATAEnd,
             scriptEnd: '</script>'
           },
           'meta-json-ld': {
@@ -2092,8 +2092,8 @@ var DO = {
           },
           'meta-trig': {
             scriptStart: '<script id="meta-trig" title="TriG" type="application/trig">',
-            cdataStart: DO.C.CDATAStart + '\n',
-            cdataEnd: '\n' + DO.C.CDATAEnd,
+            cdataStart: '# ' + DO.C.CDATAStart + '\n',
+            cdataEnd: '\n#' + DO.C.CDATAEnd,
             scriptEnd: '</script>'
           }
         }

--- a/scripts/do.js
+++ b/scripts/do.js
@@ -2081,7 +2081,7 @@ var DO = {
           'meta-turtle': {
             scriptStart: '<script id="meta-turtle" title="Turtle" type="text/turtle">',
             cdataStart: '# ' + DO.C.CDATAStart + '\n',
-            cdataEnd: '\n#' + DO.C.CDATAEnd,
+            cdataEnd: '\n# ' + DO.C.CDATAEnd,
             scriptEnd: '</script>'
           },
           'meta-json-ld': {
@@ -2093,7 +2093,7 @@ var DO = {
           'meta-trig': {
             scriptStart: '<script id="meta-trig" title="TriG" type="application/trig">',
             cdataStart: '# ' + DO.C.CDATAStart + '\n',
-            cdataEnd: '\n#' + DO.C.CDATAEnd,
+            cdataEnd: '\n# ' + DO.C.CDATAEnd,
             scriptEnd: '</script>'
           }
         }


### PR DESCRIPTION
The current implementation inserts <script> </script> tag twice after the edit existed embeded code and added `#` for some types. 