### PR TITLE
Chore: update dependencies and fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "url": "https://github.com/linkeddata/dokieli/issues"
   },
   "homepage": "https://dokie.li/",
+  "engines" : { 
+    "npm" : ">=8.0.0",
+    "node" : ">=16.0.0"
+  },
   "dependencies": {
     "buffer": "^6.0.3",
     "d3-force": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "dokieli is a client-side editor for decentralised article publishing, annotations and social interactions",
   "main": "./src/dokieli.js",
   "scripts": {
-    "build-dist": "webpack --progress --colors",
+    "build-dist": "webpack --progress --color",
     "build": "npm run build-dist",
     "standard": "standard src/auth.js src/doc.js src/fetcher.js src/graph.js src/inbox.js src/simplerdf.js src/uri.js src/util.js ",
     "test": "npm run standard",
-    "watch": "webpack --progress --colors --watch",
-    "minify": "webpack --progress --colors -p"
+    "watch": "webpack --progress --color --watch",
+    "minify": "webpack --progress --color && uglifyjs scripts/dokieli.js --output scripts/dokieli.js",
+    "postinstall": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -30,27 +31,35 @@
   },
   "homepage": "https://dokie.li/",
   "dependencies": {
+    "buffer": "^6.0.3",
     "d3-force": "^2.0.1",
     "d3-selection": "^1.4.1",
     "fs": "0.0.1-security",
     "medium-editor": "^5.23.3",
     "medium-editor-tables": "^0.6.1",
-    "node-fetch": "^2.6.1",
-    "npm": "^6.14.11",
-    "rdf-parser-rdfa": "git://github.com/rdf-ext/rdf-parser-rdfa.git#master",
+    "node-fetch": "^3.2.3",
+    "npm": "^8.5.5",
+    "patch-package": "^6.4.7",
+    "process": "^0.11.10",
+    "rdf-parser-rdfa": "https://github.com/rdf-ext/rdf-parser-rdfa.git#master",
     "rdf-store-ldp": "^0.3.1",
-    "shower": "git://github.com/shower/core.git#master",
+    "shower": "https://github.com/shower/core.git#main",
     "simplerdf": "^0.2.14",
     "simplerdf-parse": "^0.1.3",
     "solid-auth-client": "^2.5.0",
     "trackjs": "^3.7.3",
-    "webpack-core": "^0.6.9",
     "wrapper-webpack-plugin": "^2.1.0"
   },
   "devDependencies": {
-    "standard": "^14.3.3",
-    "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.11"
+    "standard": "^16.0.4",
+    "uglify-js": "^3.15.3",
+    "webpack": "^5.70.0",
+    "webpack-cli": "^4.9.2"
+  },
+  "overrides": {
+    "node-fetch": "^3.2.3",
+    "ansi-regex": "^5.0.0",
+    "xmldom": "https://github.com/xmldom/xmldom.git#master"
   },
   "standard": {
     "globals": [

--- a/patches/wrapper-webpack-plugin+2.1.0.patch
+++ b/patches/wrapper-webpack-plugin+2.1.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/wrapper-webpack-plugin/wrapper-webpack-plugin.js b/node_modules/wrapper-webpack-plugin/wrapper-webpack-plugin.js
+index 6ad181c..caffbe2 100644
+--- a/node_modules/wrapper-webpack-plugin/wrapper-webpack-plugin.js
++++ b/node_modules/wrapper-webpack-plugin/wrapper-webpack-plugin.js
+@@ -1,6 +1,5 @@
+ 'use strict';
+ 
+-const ConcatSource = require("webpack-sources").ConcatSource;
+ const ModuleFilenameHelpers = require("webpack/lib/ModuleFilenameHelpers");
+ 
+ class WrapperPlugin {
+@@ -27,6 +26,8 @@ class WrapperPlugin {
+ 	}
+ 
+ 	apply(compiler) {
++		const WebpackSources = compiler.webpack.sources;
++		const ConcatSource = WebpackSources.ConcatSource;
+ 		const header = this.header;
+ 		const footer = this.footer;
+ 		const tester = {test: this.test};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-const webpack = require('webpack')
+const webpack = require("webpack");
 const path = require("path");
 const fs = require("fs");
 const WrapperPlugin = require("wrapper-webpack-plugin");
@@ -24,9 +24,9 @@ module.exports = {
       stream: false,
       "stream-browserify": false,
       crypto: false,
-      buffer: require.resolve("buffer/"),
+      buffer: require.resolve("buffer/")
     },
-    extensions: [".ts", ".js", ".mjs"],
+    extensions: [".ts", ".js", ".mjs"]
   },
   mode: "none",
   entry: ["./src/dokieli.js"],
@@ -34,16 +34,16 @@ module.exports = {
     path: path.join(__dirname, "/scripts/"),
     filename: "dokieli.js",
     library: "DO",
-    libraryTarget: "window",
+    libraryTarget: "window"
   },
   module: {
     rules: [
       {
         test: /\.js$/,
         // loader: 'babel-loader',
-        exclude: /node_modules/,
-      },
-    ],
+        exclude: /node_modules/
+      }
+    ]
   },
   externals: {
     "node-fetch": "fetch",
@@ -51,19 +51,19 @@ module.exports = {
     "whatwg-url": "window",
     "isomorphic-fetch": "fetch",
     "@trust/webcrypto": "crypto",
-    "solid-auth-client": ["solid", "auth"],
+    "solid-auth-client": ["solid", "auth"]
   },
   devtool: "source-map",
 
   plugins: [
     new WrapperPlugin({
-      header: headerDoc,
+      header: headerDoc
     }),
     new webpack.ProvidePlugin({
-      process: 'process/browser',
+      process: "process/browser"
     }),
     new webpack.ProvidePlugin({
-      Buffer: ['buffer', 'Buffer'],
-  }),
-  ],
+      Buffer: ["buffer", "Buffer"]
+    })
+  ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,41 +1,69 @@
-const path = require('path')
-const fs = require('fs')
-const WrapperPlugin = require('wrapper-webpack-plugin')
-const headerDoc = fs.readFileSync(require.resolve('solid-auth-client/dist-lib/solid-auth-client.bundle.js'), 'utf8') + '\n';
+const webpack = require('webpack')
+const path = require("path");
+const fs = require("fs");
+const WrapperPlugin = require("wrapper-webpack-plugin");
+const headerDoc =
+  fs.readFileSync(
+    require.resolve("solid-auth-client/dist-lib/solid-auth-client.bundle.js"),
+    "utf8"
+  ) + "\n";
 
 module.exports = {
+  resolve: {
+    modules: [path.join(__dirname, "node_modules")],
+    fallback: {
+      fs: false,
+      tls: false,
+      net: false,
+      path: false,
+      zlib: false,
+      http: false,
+      https: false,
+      url: false,
+      "https-browserify": false,
+      stream: false,
+      "stream-browserify": false,
+      crypto: false,
+      buffer: require.resolve("buffer/"),
+    },
+    extensions: [".ts", ".js", ".mjs"],
+  },
   mode: "none",
-  entry: [
-    './src/dokieli.js'
-  ],
+  entry: ["./src/dokieli.js"],
   output: {
-    path: path.join(__dirname, '/scripts/'),
-    filename: 'dokieli.js',
-    library: 'DO',
-    libraryTarget: 'window'
+    path: path.join(__dirname, "/scripts/"),
+    filename: "dokieli.js",
+    library: "DO",
+    libraryTarget: "window",
   },
   module: {
     rules: [
       {
         test: /\.js$/,
         // loader: 'babel-loader',
-        exclude: /node_modules/
-      }
-    ]
+        exclude: /node_modules/,
+      },
+    ],
   },
   externals: {
-    'node-fetch': 'fetch',
-    'text-encoding': 'TextEncoder',
-    'whatwg-url': 'window',
-    'isomorphic-fetch': 'fetch',
-    '@trust/webcrypto': 'crypto',
-    'solid-auth-client': ['solid', 'auth']
+    "node-fetch": "fetch",
+    "text-encoding": "TextEncoder",
+    "whatwg-url": "window",
+    "isomorphic-fetch": "fetch",
+    "@trust/webcrypto": "crypto",
+    "solid-auth-client": ["solid", "auth"],
   },
-  devtool: 'source-map',
+  devtool: "source-map",
 
   plugins: [
     new WrapperPlugin({
-      header: headerDoc
-    })
-  ]
-}
+      header: headerDoc,
+    }),
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+  }),
+  ],
+};


### PR DESCRIPTION
This PR updates several dependencies to fix vulnerabilities, including Webpack. The upgrade to Webpack 5 required additional work, namely config changes and patching the `wrapper-webpack-plugin` via `patch-package`, and adding some additional packages like `buffer` and `process`, as well as `uglifyjs` to use directly in the minify script.

- add uglifyjs, fix minify script
- override xmldom with secure version
- override ansi-regex with secure version
- remove webpack-core
- upgrade standard
- upgrade node-fetch and override with secure version
- add buffer and process
- patch wrapper-webpack-plugin
- upgrade webpack to v5, update config
- upgrade npm
- fix protocol in package.json

To test, run `npm install` and verify there are 0 vulnerabilities. Verify everything works as intended.