### PR TITLE
Use fork in overrides for green-turtle to prevent pulling in vulnerable code

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node-fetch": "^3.2.3",
     "ansi-regex": "^5.0.0",
     "xmldom": "https://github.com/xmldom/xmldom.git#master",
-    "green-turtle": "https://github.com/VirginiaBalseiro/green-turtle#master"
+    "green-turtle": "https://github.com/csarven/green-turtle#master"
   },
   "standard": {
     "globals": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   "overrides": {
     "node-fetch": "^3.2.3",
     "ansi-regex": "^5.0.0",
-    "xmldom": "https://github.com/xmldom/xmldom.git#master"
+    "xmldom": "https://github.com/xmldom/xmldom.git#master",
+    "green-turtle": "https://github.com/VirginiaBalseiro/green-turtle#master"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
A dependency of `rdf-parser-rdfa`, `green-turtle` exports a `tests` directory which contains code that uses log4j 1.2. While dokieli **_never runs this code_**, in this PR, out of an abundance of caution, I am using an override pointing to fork of `green-turtle` which excludes the `tests` directory so that potentially vulnerable code is not pulled into the node_modules.