### PR TITLE
Fix: unset link color so it does not incorrectly inherit from document on browser extension

### DIFF
--- a/media/css/dokieli.css
+++ b/media/css/dokieli.css
@@ -343,6 +343,10 @@ padding:0 !important;
 max-width:inherit !important;
 }
 
+.do.on a {
+  color: revert;
+}
+
 aside.do.on {
 border:1px solid #ccc;
 border-top:0;


### PR DESCRIPTION
On the browser extension, the links color inherits from the document, which in some cases might have a dark theme resulting in this: 

![image](https://user-images.githubusercontent.com/28412960/188283498-6d21a365-e198-40ba-b5da-bf8d95f7b7c2.png)

By unsetting the anchor element color for this menu, they now either default to blue or take anything set afterwards in the stylesheet: 

![image](https://user-images.githubusercontent.com/28412960/188283531-69e7cdb0-6ee3-4c50-b3ab-231845bb119b.png)
