### PR TITLE
Fix: exclude playwright tests from jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   coverageDirectory: "tests/coverage",
   coverageProvider: "v8",
   testEnvironment: "jsdom",
+  modulePathIgnorePatterns: ["e2e"],
 };


### PR DESCRIPTION
Forgot to exclude playwright tests when running jest tests. 