### PR TITLE
Fix/user menu mobile

### DIFF
--- a/media/css/dokieli.css
+++ b/media/css/dokieli.css
@@ -28,14 +28,23 @@ margin-top:0 !important;
 }
 }
 
-@media screen and (min-width: 75em){
-aside.note article {
-position: absolute !important;
-left: auto;
-right: -27%;
-z-index: 1;
-width: 25%;
+@media screen and (max-width: 700px){
+  #document-menu {
+    z-index: 1 !important;
+  }
+  #document-items {
+    z-index: 0 !important;
+  }
 }
+
+@media screen and (min-width: 75em){
+  aside.note article {
+  position: absolute !important;
+  left: auto;
+  right: -27%;
+  z-index: 1;
+  width: 25%;
+  }
 }
 
 @media screen {

--- a/tests/e2e/browser/index.spec.js
+++ b/tests/e2e/browser/index.spec.js
@@ -14,3 +14,17 @@ test("clicking on the menu button displays menu", async ({ page }) => {
   const menu = page.locator("[id=document-menu]");
   await expect(menu).toBeVisible();
 });
+
+test("clicking on the sign in button displays sign in modal", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("[id=document-menu]")).not.toBeVisible();
+
+  await page.locator("#document-menu button").click();
+  const menu = page.locator("[id=document-menu]");
+  await expect(menu).toBeVisible();
+
+  const signinbtn = page.locator("[class=signin-user]");
+  await signinbtn.click();
+  const signinmodal =  page.locator("[id=user-identity-input]");
+  await expect(signinmodal).toBeVisible();
+});

--- a/tests/e2e/browser/index.spec.js
+++ b/tests/e2e/browser/index.spec.js
@@ -15,7 +15,9 @@ test("clicking on the menu button displays menu", async ({ page }) => {
   await expect(menu).toBeVisible();
 });
 
-test("clicking on the sign in button displays sign in modal", async ({ page }) => {
+test("clicking on the sign in button displays sign in modal", async ({
+  page,
+}) => {
   await page.goto("/");
   await expect(page.locator("[id=document-menu]")).not.toBeVisible();
 
@@ -25,6 +27,6 @@ test("clicking on the sign in button displays sign in modal", async ({ page }) =
 
   const signinbtn = page.locator("[class=signin-user]");
   await signinbtn.click();
-  const signinmodal =  page.locator("[id=user-identity-input]");
+  const signinmodal = page.locator("[id=user-identity-input]");
   await expect(signinmodal).toBeVisible();
 });


### PR DESCRIPTION
This PR sets the z-index of the user menu higher than the documents items menu on mobile, so that it is accessible in small screens. 

It also adds an e2e tests for this case. 

I found some uses of z-index that might be worth revising (hence the unfortunate use of `!important`) but I think we can do that in a separate more throughout PR tidying up the CSS. 