### PR TITLE
Chore/usermenu basic e2e tests

### DIFF
--- a/tests/e2e/browser/index.spec.js
+++ b/tests/e2e/browser/index.spec.js
@@ -134,3 +134,58 @@ test("clicking on the memento button displays additional buttons", async ({
   const exportBtn = page.locator("[class=export-as-html]");
   await expect(exportBtn).toBeVisible();
 });
+
+test("clicking on the edit button button enables author mode", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator("[id=document-menu]")).not.toBeVisible();
+
+  await page.locator("#document-menu button").click();
+  const menu = page.locator("[id=document-menu]");
+  await expect(menu).toBeVisible();
+
+  const closeBtn = page.locator("[class=close]");
+  await closeBtn.click();
+
+  const editBtw = page.locator("[class=editor-enable]");
+  await editBtw.click();
+  const documentEditor = page.locator("[class=medium-editor-element]");
+  await expect(documentEditor).toHaveAttribute("contenteditable", "true");
+});
+
+test("clicking on the source button displays source modal", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator("[id=document-menu]")).not.toBeVisible();
+
+  await page.locator("#document-menu button").click();
+  const menu = page.locator("[id=document-menu]");
+  await expect(menu).toBeVisible();
+
+  const closeBtn = page.locator("[class=close]");
+  await closeBtn.click();
+
+  const sourceBtn = page.locator("[class=resource-source]");
+  await sourceBtn.click();
+  const sourceModal = page.locator("[id=source-view]");
+  await expect(sourceModal).toBeVisible();
+});
+
+test("clicking on the embed button embed data modal", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("[id=document-menu]")).not.toBeVisible();
+
+  await page.locator("#document-menu button").click();
+  const menu = page.locator("[id=document-menu]");
+  await expect(menu).toBeVisible();
+
+  const closeBtn = page.locator("[class=close]");
+  await closeBtn.click();
+
+  const embedBtn = page.locator("[class=embed-data-meta]");
+  await embedBtn.click();
+  const embedModal = page.locator("[id=embed-data-entry]");
+  await expect(embedModal).toBeVisible();
+});

--- a/tests/e2e/browser/index.spec.js
+++ b/tests/e2e/browser/index.spec.js
@@ -107,3 +107,30 @@ test("clicking on the save-as button displays save-as modal", async ({
   const saveAsModal = page.locator("[id=save-as-document]");
   await expect(saveAsModal).toBeVisible();
 });
+
+test("clicking on the memento button displays additional buttons", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator("[id=document-menu]")).not.toBeVisible();
+
+  await page.locator("#document-menu button").click();
+  const menu = page.locator("[id=document-menu]");
+  await expect(menu).toBeVisible();
+
+  const closeBtn = page.locator("[class=close]");
+  await closeBtn.click();
+
+  const mementoBtw = page.locator("[class=resource-memento]");
+  await mementoBtw.click();
+  const versionBtn = page.locator("[class=create-version]");
+  await expect(versionBtn).toBeVisible();
+  const immutableBtn = page.locator("[class=create-immutable]");
+  await expect(immutableBtn).toBeVisible();
+  const robustifyBtn = page.locator("[class=robustify-links]");
+  await expect(robustifyBtn).toBeVisible();
+  const snapshotBtn = page.locator("[class=snapshot-internet-archive]");
+  await expect(snapshotBtn).toBeVisible();
+  const exportBtn = page.locator("[class=export-as-html]");
+  await expect(exportBtn).toBeVisible();
+});


### PR DESCRIPTION
This PR finishes adding basic end-to-end tests for the basic buttons in user menu. 

to est:

- run `npm run test:e2e`
- verify tests pass