### PR TITLE
use correct path in e2e tests instead of example URL

### DIFF
--- a/tests/e2e/browser/index.spec.js
+++ b/tests/e2e/browser/index.spec.js
@@ -4,17 +4,17 @@ const AxeBuilder = require("@axe-core/playwright").default;
 test("should not have any automatically detectable accessibility issues", async ({
   page,
 }) => {
-  await page.goto("https://your-site.com/"); // 3
+  await page.goto("/");
 
-  const accessibilityScanResults = await new AxeBuilder({ page }).analyze(); // 4
+  const accessibilityScanResults = await new AxeBuilder({ page }).analyze(); 
 
-  expect(accessibilityScanResults.violations).toEqual([]); // 5
+  expect(accessibilityScanResults.violations).toEqual([]); 
 });
 
 test("should not have any automatically detectable WCAG A or AA violations", async ({
   page,
 }) => {
-  await page.goto("https://your-site.com/");
+  await page.goto("/");
 
   const accessibilityScanResults = await new AxeBuilder({ page })
     .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])


### PR DESCRIPTION
This PR fixes the e2e accessibility tests where I mistakenly left the example URL instead of using the correct path. 