### PR TITLE
Object sanitization

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -127,7 +127,7 @@ export default {
   DOMNormalisation: {
     'voidElements': ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'source', 'track', 'wbr'],
     'selfClosing': ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect', 'stop', 'use'],
-    'skipAttributes': ['aria-multiline', 'contenteditable', 'data-medium-editor-editor-index', 'data-medium-editor-element', 'data-medium-focused', 'data-placeholder', 'medium-editor-index', 'role', 'spellcheck', 'style'],
+    'skipAttributes': ['aria-multiline', 'contenteditable', 'data-placeholder', 'role', 'spellcheck', 'style'],
     'sortAttributes': true,
     'skipNodeWithClass': 'do',
     'skipNodeWithId': ['toc-nav'],
@@ -136,7 +136,7 @@ export default {
       'element': 'mark'
     },
     'replaceClassItemWith': {
-      'source': ['medium-editor-element', 'medium-editor-placeholder', 'on-document-menu'],
+      'source': ['on-document-menu'],
       'target': ''
     },
     'skipClassWithValue': '',

--- a/src/dokieli.js
+++ b/src/dokieli.js
@@ -11,7 +11,7 @@ import { getDocument, getDocumentContentNode, escapeCharacters, showActionMessag
 import { getProxyableIRI, getPathURL, stripFragmentFromString, getFragmentOrLastPath, getFragmentFromString, getURLLastPath, getLastPathSegment, forceTrailingSlash, getBaseURL, getParentURLPath, encodeString, getAbsoluteIRI, generateDataURI, getMediaTypeURIs, getPrefixedNameFromIRI } from './uri.js'
 import { getResourceGraph, getResourceOnlyRDF, traverseRDFList, getLinkRelation, getAgentName, getGraphImage, getGraphFromData, isActorType, isActorProperty, serializeGraph, getGraphLabel, getGraphLabelOrIRI, getGraphConceptLabel, getUserContacts, getAgentInbox, getLinkRelationFromHead, getLinkRelationFromRDF, sortGraphTriples, getACLResourceGraph, getAccessSubjects, getAuthorizationsMatching, getGraphRights, getGraphLicense, getGraphLanguage, getGraphDate, getGraphInbox, getGraphAuthors, getGraphEditors, getGraphContributors, getGraphPerformers, getUserLabelOrIRI, getGraphTypes, filterQuads } from './graph.js'
 import { notifyInbox, sendNotifications, postActivity } from './inbox.js'
-import { uniqueArray, fragmentFromString, hashCode, generateAttributeId, escapeRegExp, sortToLower, getDateTimeISO, getDateTimeISOFromMDY, generateUUID, matchAllIndex, isValidISBN, findPreviousDateTime, domSanitize } from './util.js'
+import { uniqueArray, fragmentFromString, hashCode, generateAttributeId, escapeRegExp, sortToLower, getDateTimeISO, getDateTimeISOFromMDY, generateUUID, matchAllIndex, isValidISBN, findPreviousDateTime, domSanitize, sanitizeObject } from './util.js'
 import { generateGeoView } from './geo.js'
 import { getLocalStorageProfile, showAutoSaveStorage, hideAutoSaveStorage, updateLocalStorageProfile } from './storage.js'
 import { showUserSigninSignout, showUserIdentityInput, setContactInfo, getSubjectInfo, restoreSession } from './auth.js'
@@ -1517,7 +1517,7 @@ DO = {
         if (user && 'object' in user) {
           // user.object.describes.Role = (DO.C.User.IRI && user.object.describes.Role) ? user.object.describes.Role : 'social';
 
-          DO.C['User'] = user.object.describes;
+          DO.C['User'] = sanitizeObject(user.object.describes);
         }
       })
     },
@@ -3572,7 +3572,7 @@ console.log(reason);
                     .then(data => {
 // console.log(data)
                       // ALLOW_UNKNOWN_PROTOCOLS is needed for namespaced attribute values that DOMPurify mistakenly interpret as an unknown protocol protocol; it will allow mailto: but strip out others it does not recognize
-                      data = domSanitize(data, { ALLOW_UNKNOWN_PROTOCOLS: true });
+                      data = domSanitize(data);
 
                       var regexp = /var redirUrl = "([^"]*)";/;
                       var match = data.match(regexp);

--- a/src/util.js
+++ b/src/util.js
@@ -203,6 +203,35 @@ function domSanitize(strHTML, options = {}) {
   return cleanHTML;
 }
 
+function sanitizeObject(input) {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return {};
+  }
+
+  const safe = {};
+
+  for (const key in input) {
+    if (!Object.prototype.hasOwnProperty.call(input, key)) continue;
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+
+    const value = input[key];
+
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      value === null
+    ) {
+      safe[key] = value;
+    }
+    else if (typeof value === 'object') {
+      safe[key] = sanitizeObject(value);
+    }
+  }
+
+  return safe;
+}
+
 function sortToLower(array, key) {
   return array.sort(function (a, b) {
     if (key) {
@@ -315,5 +344,6 @@ export {
   getFormValues,
   kebabToCamel,
   parseISODuration,
-  domSanitize
+  domSanitize,
+  sanitizeObject
 };


### PR DESCRIPTION
Sanitizes `user.object.describes` in localStorage before getting assigned back to `DO.C.User`.

This resolved about 10 synk (static code analysis tool) issues.

Aside: Synk's reporting was generally useful but it took ages to hone in on the actual code that it was complaining about.