### PR TITLE
Raise e2e and accessibility tests coverage to 84%

### DIFF
--- a/tests/e2e/browser/docs/e2e-tests-coverage.md
+++ b/tests/e2e/browser/docs/e2e-tests-coverage.md
@@ -6,12 +6,12 @@
 | Toolbar    | Unauthenticated user can see toolbar in both available modes (author and social); unauthenticated user can see all popups when clicking on buttons with an associated popup  | toolbar.spec.js |
 | Toolbar commands (author)  | Unauthenticated user; formatting commands (bold, italics, headings from level 1 to level 4, code, pre) work as expected | toolbar-commands.spec.js |
 | Bookmarks    | Authenticated user; user can create a bookmark and it is correctly reflected on the document; user can delete a bookmark  | bookmark.spec.js |
-| Quote with source    | Authenticated user; ...  |  |
+| Quote with source    | Authenticated user; ...  | quote.spec.js |
 | Citation    | Authenticated user; ...  | citation.spec.js |
 | Semantics    | Authenticated user; ...  |  |
 | Share   | Authenticated user; ...  | share.spec.js |
 | Approve / Disapprove    | Authenticated user; ...  |  |
-| Specificity   | Authenticated user; ...  |  |
+| Specificity   | Authenticated user; ...  | specificity.spec.js |
 | Comment   | Authenticated user; ...  | comment.spec.js |
 | **Document actions (new, save, save as)** ||| 
 | New   | Unauthenticated user; ...  | new.spec.js |
@@ -25,5 +25,5 @@
 | **Open** ||| 
 | Open   | Unauthenticated user; User can open a document from a URL or a local file | open.spec.js |
 | **Graph** ||| 
-| Graph   | Unauthenticated user |  |
-| **Total** | **22 features** | **14 tested (63,63%)** |
+| Graph   | Unauthenticated user | graph.spec.js |
+| **Total** | **19 features** | **16 tested (84,21%)** |

--- a/tests/e2e/browser/quote.spec.js
+++ b/tests/e2e/browser/quote.spec.js
@@ -1,0 +1,70 @@
+import { test, expect } from "./fixtures";
+import AxeBuilder from "@axe-core/playwright";
+import { select } from "./utils";
+
+test.beforeEach(async ({ auth, page }) => {
+  await auth.login();
+  await page.waitForLoadState("load");
+
+  // FIXME: This is needed to make sure we're effectively finished logging in, it should not be necessary.
+  await new Promise((resolve) => {
+    page.on("console", (msg) => {
+      if (msg.text().includes(process.env.WEBID)) {
+        resolve();
+      }
+    });
+  });
+});
+
+test("should be able to add a quote with a URL", async ({ page }) => {
+  const documentMenu = page.locator("[id=document-menu]");
+  await documentMenu.locator("button").first().click();
+  expect(documentMenu).toBeVisible();
+
+  await page.waitForSelector("button.signout-user");
+  await expect(page.locator("button.signout-user")).toBeVisible();
+  const editButton = page.locator(".editor-enable");
+  await editButton.click();
+
+  await select(page, "#summary");
+  const qButton = page.locator('[id="editor-button-q"]');
+  await qButton.click();
+  await expect(page.locator("#editor-form-q")).toBeVisible();
+  await page.locator('#q-cite').fill('https://example.org');
+  const saveButton = page.getByRole("button", { name: "Save" });
+  expect(saveButton).toBeVisible();
+  await saveButton.click();
+
+  // expect the quote to be visible
+  const quote = page.locator("q");
+  await expect(quote).toBeVisible();
+  expect(quote).toHaveAttribute("cite", "https://example.org");
+});
+
+test("quote popup has no automatically detectable accessibility issues", async ({
+  page,
+}) => {
+  const qPopup = page.locator("[id=editor-form-q]");
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .include(await qPopup.elementHandle())
+    .analyze();
+  expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test("quote popup has no WCAG A, AA, or AAA violations", async ({
+  page,
+}) => {
+  const qPopup = page.locator("[id=editor-form-q]");
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .withTags([
+      "wcag2a",
+      "wcag2aa",
+      "wcag2aaa",
+      "wcag21a",
+      "wcag21aa",
+      "wcag21aaa",
+    ])
+    .include(await qPopup.elementHandle())
+    .analyze();
+  expect(accessibilityScanResults.violations).toEqual([]);
+});

--- a/tests/e2e/browser/specificity.spec.js
+++ b/tests/e2e/browser/specificity.spec.js
@@ -1,0 +1,80 @@
+import { test, expect } from "./fixtures";
+import AxeBuilder from "@axe-core/playwright";
+import { select } from "./utils";
+
+test.beforeEach(async ({ auth, page }) => {
+  await auth.login();
+  await page.waitForLoadState("load");
+
+  // FIXME: This is needed to make sure we're effectively finished logging in, it should not be necessary.
+  await new Promise((resolve) => {
+    page.on("console", (msg) => {
+      if (msg.text().includes(process.env.WEBID)) {
+        resolve();
+      }
+    });
+  });
+});
+
+async function cleanup(page, specificity) {
+  await specificity.click();
+  await page.waitForTimeout(1000);
+  // clean up created specificity
+  await page.locator("button.delete");
+  await page.click("button.delete");
+  await expect(page.locator("sup.ref-annotation")).not.toBeVisible();
+}
+
+test.only("should be able to request to increase specificity on selected text", async ({ page }) => {
+  const documentMenu = page.locator("[id=document-menu]");
+  await documentMenu.locator('button').first().click();
+  expect(documentMenu).toBeVisible();
+
+  await page.waitForSelector("button.signout-user");
+  await expect(page.locator("button.signout-user")).toBeVisible();
+  
+  await documentMenu.locator('button').first().click();
+  expect(documentMenu).not.toBeVisible();
+
+  await select(page, "#summary");
+  const specificityButton = page.locator('[id="editor-button-specificity"]');
+  await specificityButton.click();
+  await expect(page.locator("textarea#specificity-content")).toBeVisible();
+  await page.fill("textarea#specificity-content", "This is a specificity");
+  const saveButton = page.getByRole("button", { name: "Post" });
+  expect(saveButton).toBeVisible();
+  await saveButton.click();
+
+  // FIXME: double check this is what is supposed to be put in the document (failing now)
+  const specificity = page.locator("sup.ref-annotation");
+  await expect(specificity).toBeVisible();
+  await cleanup(page, specificity);
+});
+
+test("specificity popup has no automatically detectable accessibility issues", async ({
+  page,
+}) => {
+  const specificityPopup = page.locator("[id=editor-form-specificity]");
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .include(await specificityPopup.elementHandle())
+    .analyze();
+  expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test("specificity popup has no WCAG A, AA, or AAA violations", async ({
+  page,
+}) => {
+  const specificityPopup = page.locator("[id=editor-form-specificity]");
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .withTags([
+      "wcag2a",
+      "wcag2aa",
+      "wcag2aaa",
+      "wcag21a",
+      "wcag21aa",
+      "wcag21aaa",
+    ])
+    .include(await specificityPopup.elementHandle())
+    .analyze();
+  expect(accessibilityScanResults.violations).toEqual([]);
+});


### PR DESCRIPTION
This PR adds tests for quote and specificity features.

I also updated the coverage report. I previously miscounted the features as 22, but the total features are actually 19. We now have tests for 16 of those, which makes it about 84% coverage (which means previous PRs were actually higher coverage than I thought, but oh well). 