### PR TITLE
Refactor and update report based on WCAG level

### DIFF
--- a/tests/e2e/browser/bookmark.spec.js
+++ b/tests/e2e/browser/bookmark.spec.js
@@ -12,7 +12,6 @@ test.beforeEach(async ({ auth, page }) => {
 async function cleanup(page, bookmark) {
   bookmark.click();
   await page.waitForTimeout(1000);
-  // clean up created bookmark
   await page.locator("button.delete");
   await page.click("button.delete");
   await expect(page.locator("sup.ref-annotation")).not.toBeVisible();
@@ -33,28 +32,25 @@ test("should be able to bookmark a resource", async ({ page }) => {
 
       const bookmark = page.locator("sup.ref-annotation");
       await expect(bookmark).toBeVisible();
-      await test.step("bookmark popup has no automatically detectable accessibility issues", async () => {
-        const bookmarkPopup = page.locator("[id=editor-form-bookmark]");
-        const accessibilityScanResults = await new AxeBuilder({ page })
+
+      const bookmarkPopup = page.locator("[id=editor-form-bookmark]");
+
+      await test.step("bookmark popup has no WCAG A or AA violations", async () => {
+        const results = await new AxeBuilder({ page })
+          .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
           .include(await bookmarkPopup.elementHandle())
           .analyze();
-        expect(accessibilityScanResults.violations).toEqual([]);
+        expect(results.violations).toEqual([]);
       });
 
-      await test.step("bookmark popup has no WCAG A, AA, or AAA violations", async () => {
-        const bookmarkPopup = page.locator("[id=editor-form-bookmark]");
-        const accessibilityScanResults = await new AxeBuilder({ page })
-          .withTags([
-            "wcag2a",
-            "wcag2aa",
-            "wcag2aaa",
-            "wcag21a",
-            "wcag21aa",
-            "wcag21aaa",
-          ])
+      await test.step("bookmark popup has no WCAG AAA violations", async () => {
+        const results = await new AxeBuilder({ page })
+          .withTags(["wcag2aaa", "wcag21aaa"])
           .include(await bookmarkPopup.elementHandle())
           .analyze();
-        expect(accessibilityScanResults.violations).toEqual([]);
+        if (results.violations.length > 0) {
+          console.warn("AAA issues:", results.violations);
+        }
       });
 
       await cleanup(page, bookmark);

--- a/tests/e2e/browser/citation.spec.js
+++ b/tests/e2e/browser/citation.spec.js
@@ -14,9 +14,7 @@ test.beforeEach(async ({ auth, page }) => {
       }
     });
   });
-});
 
-test("should be able to add a citation with a URL", async ({ page }) => {
   const documentMenu = page.locator("[id=document-menu]");
   await documentMenu.locator("button").first().click();
   expect(documentMenu).toBeVisible();
@@ -30,6 +28,10 @@ test("should be able to add a citation with a URL", async ({ page }) => {
   const citationButton = page.locator('[id="editor-button-citation"]');
   await citationButton.click();
   await expect(page.locator("textarea#citation-content")).toBeVisible();
+});
+
+test("should be able to add a citation with a URL", async ({ page }) => {
+
   await page.fill("textarea#citation-content", "This is a citation");
   const saveButton = page.getByRole("button", { name: "Save" });
   expect(saveButton).toBeVisible();
@@ -39,30 +41,24 @@ test("should be able to add a citation with a URL", async ({ page }) => {
   await expect(citation).toBeVisible();
 });
 
-test("citation popup has no automatically detectable accessibility issues", async ({
-  page,
-}) => {
+test("citation popup has no WCAG A/AA violations", async ({ page }) => {
   const citationPopup = page.locator("[id=editor-form-citation]");
-  const accessibilityScanResults = await new AxeBuilder({ page })
+  const aAndAaResults = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
     .include(await citationPopup.elementHandle())
     .analyze();
-  expect(accessibilityScanResults.violations).toEqual([]);
+
+  expect(aAndAaResults.violations).toEqual([]);
 });
 
-test("citation popup has no WCAG A, AA, or AAA violations", async ({
-  page,
-}) => {
+test("citation popup has no WCAG AAA violations", async ({ page }) => {
   const citationPopup = page.locator("[id=editor-form-citation]");
-  const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags([
-      "wcag2a",
-      "wcag2aa",
-      "wcag2aaa",
-      "wcag21a",
-      "wcag21aa",
-      "wcag21aaa",
-    ])
+  const aaaResults = await new AxeBuilder({ page })
+    .withTags(["wcag2aaa", "wcag21aaa"])
     .include(await citationPopup.elementHandle())
     .analyze();
-  expect(accessibilityScanResults.violations).toEqual([]);
+
+  if (aaaResults.violations.length > 0) {
+    console.warn("AAA violations found:", aaaResults.violations);
+  }
 });

--- a/tests/e2e/browser/comment.spec.js
+++ b/tests/e2e/browser/comment.spec.js
@@ -19,7 +19,6 @@ test.beforeEach(async ({ auth, page }) => {
 async function cleanup(page, comment) {
   await comment.click();
   await page.waitForTimeout(1000);
-  // clean up created comment
   await page.locator("button.delete");
   await page.click("button.delete");
   await expect(page.locator("sup.ref-annotation")).not.toBeVisible();
@@ -27,13 +26,13 @@ async function cleanup(page, comment) {
 
 test("should be able to comment a resource", async ({ page }) => {
   const documentMenu = page.locator("[id=document-menu]");
-  await documentMenu.locator('button').first().click();
+  await documentMenu.locator("button").first().click();
   expect(documentMenu).toBeVisible();
 
   await page.waitForSelector("button.signout-user");
   await expect(page.locator("button.signout-user")).toBeVisible();
-  
-  await documentMenu.locator('button').first().click();
+
+  await documentMenu.locator("button").first().click();
   expect(documentMenu).not.toBeVisible();
 
   await select(page, "#summary");
@@ -54,26 +53,28 @@ test("comment popup has no automatically detectable accessibility issues", async
   page,
 }) => {
   const commentPopup = page.locator("[id=editor-form-comment]");
-  const accessibilityScanResults = await new AxeBuilder({ page })
+  const results = await new AxeBuilder({ page })
     .include(await commentPopup.elementHandle())
     .analyze();
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(results.violations).toEqual([]);
 });
 
-test("comment popup has no WCAG A, AA, or AAA violations", async ({
-  page,
-}) => {
+test("comment popup has no WCAG A or AA violations", async ({ page }) => {
   const commentPopup = page.locator("[id=editor-form-comment]");
-  const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags([
-      "wcag2a",
-      "wcag2aa",
-      "wcag2aaa",
-      "wcag21a",
-      "wcag21aa",
-      "wcag21aaa",
-    ])
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
     .include(await commentPopup.elementHandle())
     .analyze();
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(results.violations).toEqual([]);
+});
+
+test("comment popup has no WCAG AAA violations", async ({ page }) => {
+  const commentPopup = page.locator("[id=editor-form-comment]");
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2aaa", "wcag21aaa"])
+    .include(await commentPopup.elementHandle())
+    .analyze();
+  if (results.violations.length > 0) {
+    console.warn("AAA issues:", results.violations);
+  }
 });

--- a/tests/e2e/browser/docs/e2e-tests-coverage.md
+++ b/tests/e2e/browser/docs/e2e-tests-coverage.md
@@ -1,29 +1,29 @@
-| Feature       | Requirements       | Test file       |
-|--------------|--------------------|-----------------|
-| **Menu** |||
-| Menu    | Unauthenticated user; basic menu button functionality and accessibility  | menu.spec.js |
-| **Toolbars and associated actions and commands** |||
-| Toolbar    | Unauthenticated user can see toolbar in both available modes (author and social); unauthenticated user can see all popups when clicking on buttons with an associated popup  | toolbar.spec.js |
-| Toolbar commands (author)  | Unauthenticated user; formatting commands (bold, italics, headings from level 1 to level 4, code, pre) work as expected | toolbar-commands.spec.js |
-| Bookmarks    | Authenticated user; user can create a bookmark and it is correctly reflected on the document; user can delete a bookmark  | bookmark.spec.js |
-| Quote with source    | Authenticated user; ...  | quote.spec.js |
-| Citation    | Authenticated user; ...  | citation.spec.js |
-| Semantics    | Authenticated user; ...  |  |
-| Share   | Authenticated user; ...  | share.spec.js |
-| Approve / Disapprove    | Authenticated user; ...  |  |
-| Specificity   | Authenticated user; ...  | specificity.spec.js |
-| Comment   | Authenticated user; ...  | comment.spec.js |
-| **Document actions (new, save, save as)** ||| 
-| New   | Unauthenticated user; ...  | new.spec.js |
-| Save As   | Authenticated user; ...  | save-as.spec.js |
-| Save   | Authenticated user; ...  | save.spec.js |
-| **Authentication** ||| 
-| Login   | Unauthenticated user; ...  | login.test.js |
-| Logout   | Authenticated user; ...  | login.test.js |
-| **Notifications** ||| 
-| Notifications panel  | Authenticated user; User can see notifications on side panel; clicking on a notification on the document highlights side panel  | notifications.spec.js |
-| **Open** ||| 
-| Open   | Unauthenticated user; User can open a document from a URL or a local file | open.spec.js |
-| **Graph** ||| 
-| Graph   | Unauthenticated user | graph.spec.js |
-| **Total** | **19 features** | **16 tested (84,21%)** |
+| Feature       | Requirements       | Test file       | WCAG level |
+|--------------|--------------------|-----------------|------------|
+| **Menu** | | | |
+| Menu    | Unauthenticated user; basic menu button functionality and accessibility  | menu.spec.js | AAA |
+| **Toolbars and associated actions and commands** | | | |
+| Toolbar    | Unauthenticated user can see toolbar in both available modes (author and social); unauthenticated user can see all popups when clicking on buttons with an associated popup  | toolbar.spec.js | AAA |
+| Toolbar commands (author)  | Unauthenticated user; formatting commands (bold, italics, headings from level 1 to level 4, code, pre) work as expected | toolbar-commands.spec.js | N/A |
+| Bookmarks    | Authenticated user; user can create a bookmark and it is correctly reflected on the document; user can delete a bookmark  | bookmark.spec.js |AAA |
+| Quote with source    | Authenticated user; ...  | quote.spec.js | AA |
+| Citation    | Authenticated user; ...  | citation.spec.js | AA |
+| Semantics    | Authenticated user; ...  |  | |
+| Share   | Authenticated user; ...  | share.spec.js | AAA |
+| Approve / Disapprove    | Authenticated user; ...  |  | |
+| Specificity   | Authenticated user; ...  | specificity.spec.js | AAA |
+| Comment   | Authenticated user; ...  | comment.spec.js | AAA |
+| **Document actions (new, save, save as)** | | | |
+| New   | Unauthenticated user; ...  | new.spec.js | AAA |
+| Save As   | Authenticated user; ...  | save-as.spec.js | AA |
+| Save   | Authenticated user; ...  | save.spec.js | N/A |
+| **Authentication** | | | |
+| Login   | Unauthenticated user; ...  | login.test.js | N/A |
+| Logout   | Authenticated user; ...  | login.test.js | N/A |
+| **Notifications** | | | |
+| Notifications panel  | Authenticated user; User can see notifications on side panel; clicking on a notification on the document highlights side panel  | notifications.spec.js | AAA |
+| **Open** | | | |
+| Open   | Unauthenticated user; User can open a document from a URL or a local file | open.spec.js | AA |
+| **Graph** | | | |
+| Graph   | Unauthenticated user | graph.spec.js | AA |
+| **Total** | **19 features** | **16 tested (84.21%)** | |

--- a/tests/e2e/browser/graph.spec.js
+++ b/tests/e2e/browser/graph.spec.js
@@ -23,24 +23,28 @@ test("graph loads", async ({ page }) => {
 
 test("graph modal has no automatically detectable accessibility issues", async ({ page }) => {
   const graphModal = page.locator("[id=graph-view]");
-  const accessibilityScanResults = await new AxeBuilder({ page })
+  const results = await new AxeBuilder({ page })
     .include(await graphModal.elementHandle())
     .analyze();
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(results.violations).toEqual([]);
 });
 
-test("graph modal has no WCAG A, AA, or AAA violations", async ({ page }) => {
+test("graph modal has no WCAG A or AA violations", async ({ page }) => {
   const graphModal = page.locator("[id=graph-view]");
-  const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags([
-      "wcag2a",
-      "wcag2aa",
-      "wcag2aaa",
-      "wcag21a",
-      "wcag21aa",
-      "wcag21aaa",
-    ])
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
     .include(await graphModal.elementHandle())
     .analyze();
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(results.violations).toEqual([]);
+});
+
+test("graph modal has no WCAG AAA violations", async ({ page }) => {
+  const graphModal = page.locator("[id=graph-view]");
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2aaa", "wcag21aaa"])
+    .include(await graphModal.elementHandle())
+    .analyze();
+  if (results.violations.length > 0) {
+    console.warn("AAA issues:", results.violations);
+  }
 });

--- a/tests/e2e/browser/index.spec.js
+++ b/tests/e2e/browser/index.spec.js
@@ -1,35 +1,34 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 
-test("homepage should not have any automatically detectable accessibility issues", async ({
-  page,
-}) => {
+test("homepage should not have any automatically detectable accessibility issues", async ({ page }) => {
   await page.goto("/");
-
   await page.waitForLoadState("load");
 
-  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-
-  expect(accessibilityScanResults.violations).toEqual([]);
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
 });
 
-test("homepage should not have any automatically detectable WCAG A, AA, or AAA violations", async ({
-  page,
-}) => {
+test("homepage should not have any WCAG A or AA violations", async ({ page }) => {
   await page.goto("/");
-
   await page.waitForLoadState("load");
 
-  const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags([
-      "wcag2a",
-      "wcag2aa",
-      "wcag2aaa",
-      "wcag21a",
-      "wcag21aa",
-      "wcag21aaa",
-    ])
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
     .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(results.violations).toEqual([]);
+});
+
+test("homepage WCAG AAA violations", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForLoadState("load");
+
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2aaa", "wcag21aaa"])
+    .analyze();
+
+  if (results.violations.length > 0) {
+    console.warn("WCAG AAA issues:", results.violations);
+  }
 });

--- a/tests/e2e/browser/menu.spec.js
+++ b/tests/e2e/browser/menu.spec.js
@@ -1,47 +1,40 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 
-test("menu should not have any automatically detectable accessibility issues", async ({
-  page,
-}) => {
-  await page.goto("/");
-  await page.waitForLoadState("load");
-  await expect(page.locator("#document-menu")).not.toBeVisible();
+test("menu should not have any automatically detectable accessibility issues", async ({ page }) => {
+  await openMenu(page);
 
-  await page.locator("#document-menu button").click();
-  await expect(page.locator("#document-menu")).toBeVisible();
-
-  const accessibilityScanResults = await new AxeBuilder({ page })
+  const results = await new AxeBuilder({ page })
     .include("#document-menu")
     .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(results.violations).toEqual([]);
 });
 
-test("menu should not have any automatically detectable WCAG A, AA, or AAA violations", async ({
-  page,
-}) => {
-  await page.goto("/");
-  await page.waitForLoadState("load");
-  await expect(page.locator("#document-menu")).not.toBeVisible();
+test("menu should not have any WCAG A or AA violations", async ({ page }) => {
+  await openMenu(page);
 
-  await page.locator("#document-menu button").click();
-  await expect(page.locator("#document-menu")).toBeVisible();
-
-  const accessibilityScanResults = await new AxeBuilder({ page })
+  const results = await new AxeBuilder({ page })
     .include("#document-menu")
-    .withTags([
-      "wcag2a",
-      "wcag2aa",
-      "wcag2aaa",
-      "wcag21a",
-      "wcag21aa",
-      "wcag21aaa",
-    ])
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
     .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(results.violations).toEqual([]);
 });
+
+test("menu WCAG AAA violations", async ({ page }) => {
+  await openMenu(page);
+
+  const results = await new AxeBuilder({ page })
+    .include("#document-menu")
+    .withTags(["wcag2aaa", "wcag21aaa"])
+    .analyze();
+
+  if (results.violations.length > 0) {
+    console.warn("WCAG AAA issues:", results.violations);
+  }
+});
+
 
 test("clicking on the menu button displays menu", async ({ page }) => {
   await page.goto("/");

--- a/tests/e2e/browser/new.spec.js
+++ b/tests/e2e/browser/new.spec.js
@@ -5,8 +5,6 @@ import fs from "fs";
 
 test.describe("new page", () => {
   test.beforeEach(async ({ page }) => {
-    {
-    }
     await page.route("https://dokie.li/scripts/dokieli.js", async (route) => {
       const localScriptPath = path.resolve("./scripts/dokieli.js");
       const scriptContent = fs.readFileSync(localScriptPath, "utf8");
@@ -16,52 +14,48 @@ test.describe("new page", () => {
       });
     });
   });
-  test("new page should not have any automatically detectable accessibility issues", async ({
-    page,
-  }) => {
-    await page.goto("/new");
 
+  test("should not have any automatically detectable accessibility issues", async ({ page }) => {
+    await page.goto("/new");
     await page.waitForLoadState("load");
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 
-  test("new page should not have any automatically detectable WCAG A, AA, or AAA violations", async ({
-    page,
-  }) => {
+  test("should not have WCAG A or AA violations", async ({ page }) => {
     await page.goto("/new");
-
     await page.waitForLoadState("load");
 
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags([
-        "wcag2a",
-        "wcag2aa",
-        "wcag2aaa",
-        "wcag21a",
-        "wcag21aa",
-        "wcag21aaa",
-      ])
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
       .analyze();
 
-    expect(accessibilityScanResults.violations).toEqual([]);
+    expect(results.violations).toEqual([]);
   });
 
-  test("initializes a new document in author mode when navigating to /new", async ({
-    page,
-  }) => {
+  test("should not have WCAG AAA violations", async ({ page }) => {
+    await page.goto("/new");
+    await page.waitForLoadState("load");
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2aaa", "wcag21aaa"])
+      .analyze();
+
+    if (results.violations.length > 0) {
+      console.warn("WCAG AAA violations:", results.violations);
+    }
+  });
+
+  test("initializes a new document in author mode when navigating to /new", async ({ page }) => {
     await page.goto("/new");
 
-    // Check if initial elements are visible and contain the correct attributes
     const h1 = page.locator("h1");
     await expect(h1).toBeVisible();
     await expect(h1).toHaveAttribute("data-placeholder", "Title");
+
     const p = page.locator("p");
     await expect(p).toHaveAttribute("data-placeholder", "Cogito, ergo sum.");
-
-    // Check that placeholder text is visible on screen
 
     const isVisible = async (element) => {
       return element.evaluate((el) => {
@@ -76,38 +70,29 @@ test.describe("new page", () => {
 
     expect(await isVisible(h1)).toBe(true);
     expect(await getPlaceholderText(h1)).toContain("Title");
-
     expect(await isVisible(p)).toBe(true);
     expect(await getPlaceholderText(p)).toContain("Cogito, ergo sum.");
 
-    // Check if the document is editable
     const documentEditor = page.locator(".do-new.ProseMirror");
     await expect(documentEditor).toHaveAttribute("contenteditable", "true");
 
-    // Input some text
     await h1.click();
     await h1.fill("Test text");
     await h1.focus();
 
-    // Click and drag on text to select it
     const text = h1;
     const box = await text.boundingBox();
-
     await text.click();
     await page.mouse.down();
     await page.mouse.move(box.x + 30, box.y + box.height / 2);
     await page.mouse.up();
 
-    // Check if the toolbar is visible with the author mode functionality
     const toolbar = page.locator(".editor-toolbar");
     await expect(toolbar).toBeVisible();
-
     const toolbarActions = page.locator(".editor-form-actions li");
     await expect(toolbarActions).toHaveCount(18);
-    const strongButton = page.locator(".editor-toolbar #editor-button-strong");
-    await expect(strongButton).toBeVisible();
-    const emButton = page.locator(".editor-toolbar #editor-button-em");
-    await expect(emButton).toBeVisible();
+    await expect(page.locator(".editor-toolbar #editor-button-strong")).toBeVisible();
+    await expect(page.locator(".editor-toolbar #editor-button-em")).toBeVisible();
   });
 });
 
@@ -116,43 +101,43 @@ test.describe("via new button", () => {
     await page.goto("/");
     await page.waitForLoadState("load");
     await page.locator("#document-menu button").click();
-    const menu = page.locator("[id=document-menu]");
-    await expect(menu).toBeVisible();
+    await expect(page.locator("[id=document-menu]")).toBeVisible();
     await expect(page.locator(".close")).toBeVisible();
-
-    const newBtn = page.locator("[class=resource-new]");
-    await newBtn.click();
+    await page.locator("[class=resource-new]").click();
   });
 
-  test("new page should not have any automatically detectable accessibility issues", async ({
-    page,
-  }) => {
-    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-
-    expect(accessibilityScanResults.violations).toEqual([]);
+  test("should not have any automatically detectable accessibility issues", async ({ page }) => {
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
   });
 
-  test("new page should not have any automatically detectable WCAG A or AA violations", async ({
-    page,
-  }) => {
-    const accessibilityScanResults = await new AxeBuilder({ page })
+  test("should not have WCAG A or AA violations", async ({ page }) => {
+    const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
       .analyze();
+    expect(results.violations).toEqual([]);
+  });
 
-    expect(accessibilityScanResults.violations).toEqual([]);
+  test("should not have WCAG AAA violations", async ({ page }) => {
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2aaa", "wcag21aaa"])
+      .analyze();
+
+    if (results.violations.length > 0) {
+      console.warn("WCAG AAA violations:", results.violations);
+    }
   });
 
   test("initializes a new document in author mode", async ({ page }) => {
-    // Check if initial elements are visible and contain the correct attributes
     const documentEditor = page.locator(".do-new.ProseMirror");
     await expect(documentEditor).toHaveAttribute("contenteditable", "true");
+
     const h1 = page.locator("h1");
     await expect(h1).toBeVisible();
     await expect(h1).toHaveAttribute("data-placeholder", "Title");
+
     const p = page.locator("p");
     await expect(p).toHaveAttribute("data-placeholder", "Cogito, ergo sum.");
-
-    // Check that placeholder text is visible on screen
 
     const isVisible = async (element) => {
       return element.evaluate((el) => {
@@ -171,25 +156,18 @@ test.describe("via new button", () => {
     expect(await isVisible(p)).toBe(true);
     expect(await getPlaceholderText(p)).toContain("Cogito, ergo sum.");
 
-    // Check if toolbar is visible with the author mode functionality
-
-    // Input some text
     await documentEditor.click();
     await documentEditor.type("Test text");
     await expect(documentEditor).toHaveText("Test text");
 
-    // Select the text "Test text" using keyboard shortcuts
-    await documentEditor.press("Shift+ArrowLeft"); // Select the last character
+    await documentEditor.press("Shift+ArrowLeft");
 
-    // Check if the toolbar is visible with the author mode functionality
     const toolbar = page.locator(".editor-toolbar");
     await expect(toolbar).toBeVisible();
 
     const toolbarActions = page.locator(".editor-form-actions li");
     await expect(toolbarActions).toHaveCount(18);
-    const strongButton = page.locator(".editor-toolbar #editor-button-strong");
-    await expect(strongButton).toBeVisible();
-    const emButton = page.locator(".editor-toolbar #editor-button-em");
-    await expect(emButton).toBeVisible();
+    await expect(page.locator(".editor-toolbar #editor-button-strong")).toBeVisible();
+    await expect(page.locator(".editor-toolbar #editor-button-em")).toBeVisible();
   });
 });

--- a/tests/e2e/browser/notifications.spec.js
+++ b/tests/e2e/browser/notifications.spec.js
@@ -13,11 +13,7 @@ test.beforeEach(async ({ auth, page }) => {
       }
     });
   });
-});
 
-test("notifications panels displays notifications", async ({
-  page,
-}) => {
   const documentMenuButton = page.locator("#document-menu button");
   await expect(documentMenuButton).toBeVisible();
   await expect(page.locator("[id=document-menu]")).not.toBeVisible();
@@ -33,16 +29,17 @@ test("notifications panels displays notifications", async ({
 
   const notificationsBtn = page.locator("[class=resource-notifications]");
   await notificationsBtn.click();
+});
+
+test("notifications panels displays notifications", async ({ page }) => {
   const notificationsPanel = page.locator("[id=document-notifications]");
   await expect(notificationsPanel).toBeVisible();
   await page.locator("text=Checking activities").waitFor({ state: "hidden" });
   const notifications = await page.locator("blockquote");
-  // check if there are any notifications
   const notificationsCount = await notifications.count();
   expect(notificationsCount).toBeGreaterThan(0);
 });
 
-  
 test("notifications panel has no automatically detectable accessibility issues", async ({ page }) => {
   const notificationsPanel = page.locator("[id=document-notifications]");
   const accessibilityScanResults = await new AxeBuilder({ page })
@@ -51,17 +48,26 @@ test("notifications panel has no automatically detectable accessibility issues",
   expect(accessibilityScanResults.violations).toEqual([]);
 });
 
-test("notifications panel has no WCAG A, AA, or AAA violations", async ({ page }) => {
+test("notifications panel has no WCAG A or AA violations", async ({ page }) => {
   const notificationsPanel = page.locator("[id=document-notifications]");
   const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags([
-      "wcag2a", "wcag2aa", "wcag2aaa",
-      "wcag21a", "wcag21aa", "wcag21aaa"
-    ])
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
     .include(await notificationsPanel.elementHandle())
     .analyze();
   expect(accessibilityScanResults.violations).toEqual([]);
 });
+
+test("notifications panel has no WCAG AAA violations", async ({ page }) => {
+  const notificationsPanel = page.locator("[id=document-notifications]");
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2aaa", "wcag21aaa"])
+    .include(await notificationsPanel.elementHandle())
+    .analyze();
+  if (results.violations.length > 0) {
+    console.warn("AAA issues:", results.violations);
+  }
+});
+
 
 test("annotations are highlighted in the text", async ({ page }) => {
   const documentMenuButton = page.locator("#document-menu button");

--- a/tests/e2e/browser/open.spec.js
+++ b/tests/e2e/browser/open.spec.js
@@ -51,8 +51,7 @@ test("opens new document from local file", async ({ page }) => {
   await expect(documentContent).toBeVisible();
 });
 
-
-test("open modal should not have any automatically detectable WCAG A, AA, or AAA violations", async ({
+test("open modal should not have any automatically detectable WCAG A or AA violations", async ({
   page,
 }) => {
   await page.goto("/");
@@ -73,12 +72,37 @@ test("open modal should not have any automatically detectable WCAG A, AA, or AAA
     .withTags([
       "wcag2a",
       "wcag2aa",
-      "wcag2aaa",
-      "wcag21a",
-      "wcag21aa",
-      "wcag21aaa",
     ])
     .analyze();
 
-  expect(accessibilityScanResults.violations).toEqual([]);
+  expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test("open modal should not have any automatically detectable WCAG AAA violations", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator("[id=document-menu]")).not.toBeVisible();
+
+  await page.locator("#document-menu button").click();
+  const menu = page.locator("[id=document-menu]");
+  await expect(menu).toBeVisible();
+  await expect(page.locator(".close")).toBeVisible();
+
+  const openBtw = page.locator("[class=resource-open]");
+  await openBtw.click();
+  const openModal = page.locator("[id=open-document]");
+  await expect(openModal).toBeVisible();
+
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .include("#open-document")
+    .withTags([
+      "wcag2aaa", 
+      "wcag21aaa"
+    ])
+    .analyze();
+
+  if (accessibilityScanResults.violations.length > 0) {
+    console.warn("WCAG AAA Violations:", accessibilityScanResults.violations);
+  }
 });

--- a/tests/e2e/browser/quote.spec.js
+++ b/tests/e2e/browser/quote.spec.js
@@ -14,9 +14,6 @@ test.beforeEach(async ({ auth, page }) => {
       }
     });
   });
-});
-
-test("should be able to add a quote with a URL", async ({ page }) => {
   const documentMenu = page.locator("[id=document-menu]");
   await documentMenu.locator("button").first().click();
   expect(documentMenu).toBeVisible();
@@ -29,6 +26,9 @@ test("should be able to add a quote with a URL", async ({ page }) => {
   await select(page, "#summary");
   const qButton = page.locator('[id="editor-button-q"]');
   await qButton.click();
+});
+
+test("should be able to add a quote with a URL", async ({ page }) => {
   await expect(page.locator("#editor-form-q")).toBeVisible();
   await page.locator('#q-cite').fill('https://example.org');
   const saveButton = page.getByRole("button", { name: "Save" });
@@ -51,7 +51,7 @@ test("quote popup has no automatically detectable accessibility issues", async (
   expect(accessibilityScanResults.violations).toEqual([]);
 });
 
-test("quote popup has no WCAG A, AA, or AAA violations", async ({
+test("quote popup has no WCAG A or AA violations", async ({
   page,
 }) => {
   const qPopup = page.locator("[id=editor-form-q]");
@@ -59,12 +59,27 @@ test("quote popup has no WCAG A, AA, or AAA violations", async ({
     .withTags([
       "wcag2a",
       "wcag2aa",
-      "wcag2aaa",
       "wcag21a",
       "wcag21aa",
-      "wcag21aaa",
     ])
     .include(await qPopup.elementHandle())
     .analyze();
   expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+
+test("quote popup has no WCAG AAA violations", async ({
+  page,
+}) => {
+  const qPopup = page.locator("[id=editor-form-q]");
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .withTags([
+      "wcag2aaa",
+      "wcag21aaa",
+    ])
+    .include(await qPopup.elementHandle())
+    .analyze();
+  if (accessibilityScanResults.violations.length > 0) {
+    console.warn("AAA issues:", accessibilityScanResults.violations);
+  }
 });

--- a/tests/e2e/browser/save-as.spec.js
+++ b/tests/e2e/browser/save-as.spec.js
@@ -40,7 +40,7 @@ test("saveAs saves copy of document in selected storage location", async ({ page
   // TODO: cleanup
 });
 
-test("save-as modal should not have any automatically detectable WCAG A, AA, or AAA violations", async ({
+test("save-as modal should not have any automatically detectable WCAG A and AA", async ({
   page,
 }) => {
   const documentMenuButton = page.locator("#document-menu > button");
@@ -63,12 +63,41 @@ test("save-as modal should not have any automatically detectable WCAG A, AA, or 
     .withTags([
       "wcag2a",
       "wcag2aa",
-      "wcag2aaa",
       "wcag21a",
       "wcag21aa",
-      "wcag21aaa",
     ])
     .analyze();
 
   expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test("save-as modal should not have any automatically detectable WCAG AAA violations", async ({
+  page,
+}) => {
+  const documentMenuButton = page.locator("#document-menu > button");
+  await expect(documentMenuButton).toBeVisible();
+  await expect(page.locator("[id=document-menu]")).not.toBeVisible();
+
+  await documentMenuButton.click();
+  await expect(page.locator("[id=document-menu]")).toBeVisible();
+  await expect(page.locator(".close")).toBeVisible();
+  await expect(page.locator("button.signout-user")).toBeVisible();
+
+  const saveAsBtn = page.locator("[class=resource-save-as]");
+  await saveAsBtn.click();
+
+  const saveAsModal = page.locator("[id=save-as-document]");
+  await expect(saveAsModal).toBeVisible();
+
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .include("#save-as-document")
+    .withTags([
+      "wcag2aaa",
+      "wcag21aaa",
+    ])
+    .analyze();
+
+  if (accessibilityScanResults.violations.length > 0) {
+    console.warn("AAA issues:", accessibilityScanResults.violations);
+  }
 });

--- a/tests/e2e/browser/share.spec.js
+++ b/tests/e2e/browser/share.spec.js
@@ -73,7 +73,7 @@ test("share modal has no automatically detectable accessibility issues", async (
   expect(accessibilityScanResults.violations).toEqual([]);
 });
 
-test("share modal has no WCAG A, AA, or AAA violations", async ({
+test("share modal has no WCAG A or AA violations", async ({
   page,
 }) => {
   const shareModal = page.locator("[id=share-resource]");
@@ -81,12 +81,26 @@ test("share modal has no WCAG A, AA, or AAA violations", async ({
     .withTags([
       "wcag2a",
       "wcag2aa",
-      "wcag2aaa",
       "wcag21a",
       "wcag21aa",
-      "wcag21aaa",
     ])
     .include(await shareModal.elementHandle())
     .analyze();
   expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test("share modal has no WCAG AAA violations", async ({
+  page,
+}) => {
+  const shareModal = page.locator("[id=share-resource]");
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .withTags([
+      "wcag2aaa",
+      "wcag21aaa",
+    ])
+    .include(await shareModal.elementHandle())
+    .analyze();
+  if (accessibilityScanResults.violations.length > 0) {
+    console.warn("AAA issues:", accessibilityScanResults.violations);
+  }
 });

--- a/tests/e2e/browser/specificity.spec.js
+++ b/tests/e2e/browser/specificity.spec.js
@@ -25,15 +25,17 @@ async function cleanup(page, specificity) {
   await expect(page.locator("sup.ref-annotation")).not.toBeVisible();
 }
 
-test("should be able to request to increase specificity on selected text", async ({ page }) => {
+test("should be able to request to increase specificity on selected text", async ({
+  page,
+}) => {
   const documentMenu = page.locator("[id=document-menu]");
-  await documentMenu.locator('button').first().click();
+  await documentMenu.locator("button").first().click();
   expect(documentMenu).toBeVisible();
 
   await page.waitForSelector("button.signout-user");
   await expect(page.locator("button.signout-user")).toBeVisible();
-  
-  await documentMenu.locator('button').first().click();
+
+  await documentMenu.locator("button").first().click();
   expect(documentMenu).not.toBeVisible();
 
   await select(page, "#summary");
@@ -61,20 +63,22 @@ test("specificity popup has no automatically detectable accessibility issues", a
   expect(accessibilityScanResults.violations).toEqual([]);
 });
 
-test("specificity popup has no WCAG A, AA, or AAA violations", async ({
-  page,
-}) => {
+test("specificity popup has no WCAG A or AA violations", async ({ page }) => {
   const specificityPopup = page.locator("[id=editor-form-specificity]");
   const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags([
-      "wcag2a",
-      "wcag2aa",
-      "wcag2aaa",
-      "wcag21a",
-      "wcag21aa",
-      "wcag21aaa",
-    ])
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
     .include(await specificityPopup.elementHandle())
     .analyze();
   expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test("specificity popup has no WCAG AAA violations", async ({ page }) => {
+  const specificityPopup = page.locator("[id=editor-form-specificity]");
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .withTags(["wcag2aaa", "wcag21aaa"])
+    .include(await specificityPopup.elementHandle())
+    .analyze();
+  if (accessibilityScanResults.violations.length > 0) {
+    console.log("AAA issues:", accessibilityScanResults.violations);
+  }
 });


### PR DESCRIPTION
This PR refactors all accessibility tests to split between A/AA and AAA, so that the latter can be non-blocking. 

It also updates the report to have a WCAG level column which reflects the current status for each feature.