### PR TITLE
Add Service Workers

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,83 @@
+const CACHE_NAME = 'dokieli-app-cache-v1';
+
+const APP_FILES = [
+  '/',
+  '/docs',
+  '/media/css/basic.css',
+  '/media/css/dokieli.css',
+  '/media/images/logo.png',
+  '/scripts/dokieli.js'
+];
+
+  // does not wait for the service worker to be activated before using it - TODO: is this correct?
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(APP_FILES))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  const url = new URL(req.url);
+
+  if (req.method !== 'GET') return;
+  if (url.origin !== self.location.origin) return;
+  if (!APP_FILES.includes(url.pathname)) return; 
+
+  //XXX: Keep false when not developing from localhost
+  // const simulateOffline = false;
+
+  event.respondWith(
+    (async () => {
+      // if (simulateOffline) {
+      //   console.log("Simulating offline for localhost: ", req.url);
+      //   // Simulated offline for localhost: serve from cache only
+      //   const cached = await caches.match(req);
+      //   if (cached) return cached;
+      //   return new Response('cache not found', {
+      //     status: 503,
+      //     statusText: 'Service Unavailable',
+      //     headers: { 'Content-Type': 'text/plain' },
+      //   });
+      // }
+
+      // online behavior: fetch and update cache
+      try {
+        console.log("fetching: ", req.url);
+        const networkResponse = await fetch(req);
+        const responseClone = networkResponse.clone();
+        const cache = await caches.open(CACHE_NAME);
+
+        console.log("caching response for ", req.url);
+        await cache.put(req, responseClone);
+        return networkResponse;
+        // if it cannot fetch it serves cached
+      } catch (err) {
+        const cached = await caches.match(req);
+        console.log(cached)
+        console.log("fetch failed, serving from cache: ", req.url);
+        if (cached) return cached;
+        return new Response('cache not found', {
+          status: 503,
+          statusText: 'Service Unavailable',
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }
+    })()
+  );
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,6 +2,7 @@ const CACHE_NAME = 'dokieli-app-cache-v1';
 
 const APP_FILES = [
   '/',
+  '/index.html',
   '/docs',
   '/media/css/basic.css',
   '/media/css/dokieli.css',
@@ -9,7 +10,6 @@ const APP_FILES = [
   '/scripts/dokieli.js'
 ];
 
-  // does not wait for the service worker to be activated before using it - TODO: is this correct?
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(APP_FILES))
@@ -34,49 +34,33 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const req = event.request;
   const url = new URL(req.url);
+  const cacheKey = url.pathname;
 
   if (req.method !== 'GET') return;
   if (url.origin !== self.location.origin) return;
   if (!APP_FILES.includes(url.pathname)) return; 
 
-  //XXX: Keep false when not developing from localhost
-  // const simulateOffline = false;
-
   event.respondWith(
     (async () => {
-      // if (simulateOffline) {
-      //   console.log("Simulating offline for localhost: ", req.url);
-      //   // Simulated offline for localhost: serve from cache only
-      //   const cached = await caches.match(req);
-      //   if (cached) return cached;
-      //   return new Response('cache not found', {
-      //     status: 503,
-      //     statusText: 'Service Unavailable',
-      //     headers: { 'Content-Type': 'text/plain' },
-      //   });
-      // }
-
-      // online behavior: fetch and update cache
       try {
-        console.log("fetching: ", req.url);
+        // console.log("fetching: ", req.url);
         const networkResponse = await fetch(req);
         const responseClone = networkResponse.clone();
         const cache = await caches.open(CACHE_NAME);
-
-        console.log("caching response for ", req.url);
-        await cache.put(req, responseClone);
+        // console.log("caching response for ", req.url);
+        await cache.put(cacheKey, responseClone);
         return networkResponse;
-        // if it cannot fetch it serves cached
       } catch (err) {
-        const cached = await caches.match(req);
-        console.log(cached)
-        console.log("fetch failed, serving from cache: ", req.url);
+        // console.log(err)
+        // console.log(req)
+        const cached = await caches.match(cacheKey);
+        // console.log(cached)
+        // console.log("fetch failed, serving from cache: ", req.url);
         if (cached) return cached;
-        return new Response('cache not found', {
-          status: 503,
-          statusText: 'Service Unavailable',
-          headers: { 'Content-Type': 'text/plain' },
-        });
+        else {
+          throw new Error(err)
+          // console.log(req.url)
+        }
       }
     })()
   );

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,8 @@ import DO from './dokieli.js';
 
 export default {
   init: function(url) {
+    DO.U.initServiceWorker();
+
     var contentNode = DO.U?.getContentNode(document);
     if (contentNode) {
       DO.U.initButtons();

--- a/src/dokieli.js
+++ b/src/dokieli.js
@@ -1649,6 +1649,18 @@ DO = {
       }
     },
 
+    initServiceWorker: function () {
+      if ('serviceWorker' in navigator && !Config.WebExtensionEnabled) {
+        navigator.serviceWorker.register('/service-worker.js')
+          .then(() => {
+            console.log('Service Worker registered');
+          })
+          .catch((err) => {
+            console.error('Service Worker registration failed:', err);
+          });
+      }
+    },
+
     initLocalStorage: function() {
       getLocalStorageItem(DO.C.DocumentURL).then(collection => {
         if (!collection) {

--- a/src/dokieli.js
+++ b/src/dokieli.js
@@ -1651,7 +1651,7 @@ DO = {
 
     initServiceWorker: function () {
       if ('serviceWorker' in navigator && !Config.WebExtensionEnabled) {
-        navigator.serviceWorker.register('/service-worker.js')
+        navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
           .then(() => {
             console.log('Service Worker registered');
           })


### PR DESCRIPTION
Uses [Service Workers](https://www.w3.org/TR/service-workers/) to cache application code and assets so that dokieli works offline.

The cache strategy is network-first so that it prioritises getting the most up to date version and using cache as fallback.