### PR TITLE
Reorganize toolbars for easier navigation

### DIFF
--- a/media/css/dokieli.css
+++ b/media/css/dokieli.css
@@ -3838,7 +3838,7 @@ h1 + div p:first-child {
       padding: 15px;
       text-decoration: none;
       span {
-        font-size:1.25em;
+        font-size:1.5em;
       }
     }
       .editor-toolbar .editor-form-actions li button:focus {
@@ -3981,11 +3981,7 @@ height:auto;
     .editor-toolbar li button:not(:disabled):hover{
       background-color: #EEE;
       color: #080; }
-    .editor-toolbar li button:not(:disabled).editor-button-active svg,
-    .editor-toolbar li button:not(:disabled):hover svg, 
-    .editor-toolbar li button:not(:disabled):focus {
-      fill: #080; }
-
+      
     .editor-toolbar li button:disabled {
       cursor: default;
     }
@@ -4016,6 +4012,265 @@ height:auto;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
+
+.editor-toolbar .editor-dropdown-panel {
+  display: none;
+  overflow-x: unset;
+  flex-wrap: unset;
+}
+.editor-toolbar .editor-dropdown-panel.editor-dropdown-panel-active {
+  display: flex;
+  padding: 0;
+}
+
+.editor-submenu-button {
+  display: none !important;
+}
+
+#document-editor.editor-toolbar {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18), 0 0 0 1px rgba(0, 0, 0, 0.07);
+}
+
+.editor-toolbar .editor-form-actions {
+  align-items: stretch;
+  overflow-y: hidden;
+}
+
+.editor-toolbar .editor-form-actions li {
+  display: flex;
+  align-items: stretch;
+}
+
+.editor-toolbar .editor-form-actions li button {
+  padding: 0 10px;
+  align-items: center;
+  justify-content: center;
+}
+
+.editor-toolbar .editor-form-actions li:first-child .editor-dropdown-trigger,
+.editor-toolbar .editor-form-actions li:first-child button {
+  border-bottom-left-radius: 10px;
+  border-top-left-radius: 10px;
+}
+
+.editor-toolbar .editor-form-actions li:last-child .editor-mode-toggle-btn,
+.editor-toolbar .editor-form-actions li:last-child button {
+  border-bottom-right-radius: 10px;
+  border-top-right-radius: 10px;
+}
+
+.editor-toolbar .editor-form-actions li.editor-dropdown-menu,
+.editor-toolbar .editor-form-actions li.editor-mode-toggle {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.editor-toolbar .editor-form-actions li.editor-dropdown-menu .editor-dropdown-trigger {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  padding: 0 10px;
+  font-size: 0.9em;
+  font-weight: bold;
+  letter-spacing: 0.01em;
+  height: 100%;
+  box-sizing: border-box;
+  cursor: pointer;
+  background-color: #fff;
+  border: none;
+  transition: background-color .2s ease-in;
+}
+.editor-toolbar .editor-form-actions li.editor-dropdown-menu .editor-dropdown-trigger:hover,
+.editor-toolbar .editor-form-actions li.editor-dropdown-menu .editor-dropdown-trigger.editor-button-active {
+  background-color: #EEE;
+  color: #080;
+}
+.editor-toolbar .editor-form-actions li.editor-dropdown-menu .editor-dropdown-trigger:hover svg,
+.editor-toolbar .editor-form-actions li.editor-dropdown-menu .editor-dropdown-trigger.editor-button-active svg {
+  fill: #080;
+}
+
+.editor-blocktype-select {
+  height: 100%;
+  border: none;
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.85em;
+  font-weight: 600;
+  padding: 0 0.4em 0 0.75em;
+  cursor: pointer;
+  min-width: 7.5em;
+  border-radius: 10px 0 0 10px;
+  color: #111;
+  outline: none;
+}
+.editor-blocktype-select:hover,
+.editor-blocktype-select:focus {
+  background: #eee;
+  color: #080;
+}
+.editor-blocktype-select option[value="h1"] { font-size: 1.3em; font-weight: 700; }
+.editor-blocktype-select option[value="h2"] { font-size: 1.15em; font-weight: 700; }
+.editor-blocktype-select option[value="h3"] { font-size: 1em; font-weight: 600; }
+.editor-blocktype-select option[value="p"]  { font-size: 0.85em; font-weight: 400; }
+
+.editor-dropdown-panel {
+  position: absolute;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14), 0 1px 4px rgba(0, 0, 0, 0.08);
+  min-width: 220px;
+  padding: 5px 0;
+  z-index: 100;
+  list-style: none;
+  margin: 4px 0 0;
+  flex-direction: column;
+  color: #111;
+}
+
+.editor-dropdown-section-label {
+  padding: 0.55em 0.9em 0.25em;
+  font-weight: 700;
+  font-size: 0.75em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #888;
+  cursor: default;
+  list-style: none;
+  pointer-events: none;
+  border-top: 1px solid rgba(0,0,0,0.07);
+  margin-top: 3px;
+}
+.editor-dropdown-section-label:first-child {
+  border-top: none;
+  margin-top: 0;
+  padding: 1em;
+}
+
+.editor-dropdown-panel li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.editor-dropdown-panel li button.editor-dropdown-item {
+  width: 100%;
+  min-height: max-content;
+  text-align: left;
+  padding: 0.45em 0.9em;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  font-family: inherit;
+  font-size: 1em;
+  font-weight: normal;
+  color: #111;
+  transition: background-color 0.1s;
+}
+.editor-dropdown-panel li button.editor-dropdown-item:hover {
+  background-color: #f0f5f0;
+  color: #060;
+}
+.editor-dropdown-item-label {
+  font-weight: 500;
+}
+.editor-dropdown-item-desc {
+  color: #777;
+  margin-top: 0.08em;
+  font-weight: normal;
+}
+
+.editor-dropdown-panel li button.editor-dropdown-item.editor-dropdown-item-current {
+  background-color: #f0f5f0;
+  color: #060;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+.editor-dropdown-item-current::after {
+  content: '✓';
+  font-size: 0.8em;
+  color: #080;
+  padding-left: 0.75em;
+  flex-shrink: 0;
+}
+
+.editor-toolbar .editor-form-actions li button svg {
+  width: 15px;
+  height: 15px;
+  fill: #111;
+  flex-shrink: 0;
+}
+.editor-toolbar .editor-form-actions li button svg[stroke] {
+  fill: none;
+  stroke: #111;
+}
+.editor-toolbar .editor-form-actions li button:hover svg,
+.editor-toolbar .editor-form-actions li button.editor-button-active svg {
+  fill: #080;
+}
+.editor-toolbar .editor-form-actions li button:hover svg[stroke],
+.editor-toolbar .editor-form-actions li button.editor-button-active svg[stroke] {
+  fill: none;
+  stroke: #080;
+}
+
+.editor-dropdown-panel li button.editor-dropdown-item.has-icon {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0.55em;
+}
+.editor-dropdown-item-icon {
+  flex-shrink: 0;
+  color: #000;
+  margin-top: 1px;
+  line-height: 0;
+  display: flex;
+  align-items: center;
+}
+.editor-dropdown-item-icon svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+.editor-dropdown-item-text {
+  display: flex;
+  flex-direction: column;
+}
+.editor-dropdown-panel li button.editor-dropdown-item.has-icon:hover .editor-dropdown-item-icon {
+  color: #060;
+}
+
+.editor-toolbar .editor-form-actions li.editor-mode-toggle .editor-mode-toggle-btn {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  box-sizing: border-box;
+  white-space: nowrap;
+  font-style: italic;
+  font-size: 0.8em;
+  padding: 0 12px;
+  opacity: 0.65;
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+  cursor: pointer;
+  border-top: none;
+  border-right: none;
+  border-bottom: none;
+  transition: background-color .2s ease-in, opacity .2s ease-in;
+}
+.editor-toolbar .editor-form-actions li.editor-mode-toggle .editor-mode-toggle-btn:hover {
+  opacity: 1;
+  background-color: #EEE;
+  color: #080;
+}
 
 .editor-form {
   background: #fff;

--- a/media/css/dokieli.css
+++ b/media/css/dokieli.css
@@ -4160,7 +4160,7 @@ height:auto;
 }
 .editor-dropdown-panel li button.editor-dropdown-item {
   width: 100%;
-  min-height: max-content;
+  height: max-content;
   text-align: left;
   padding: 0.45em 0.9em;
   background: none;

--- a/media/css/dokieli.css
+++ b/media/css/dokieli.css
@@ -2536,7 +2536,7 @@ margin-top:0;
 
 .do select {
 padding: 0.75em;
-font-size: 16px;
+font-size: 1em;
 border: 2px solid #ccc;
 border-radius: 5px;
 background: #fff;
@@ -3968,29 +3968,30 @@ height:auto;
   background: linear-gradient(to bottom, #fff, rgba(0, 0, 0, 0.75));
   border-radius: 5px;
   box-shadow: 0 0 3px #000; }
-  .editor-toolbar li button {
-    font-weight:bold;
-    background-color: #fff;
-    border: 0;
-    outline: none;
-    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
-    color: #000;
-    height: 50px;
-    min-width: 50px;
-    -webkit-transition: background-color .2s ease-in;
-            transition: background-color .2s ease-in; }
-    .editor-toolbar li button:not(:disabled):hover{
-      background-color: #EEE;
-      color: #080; }
+.editor-toolbar li button {
+  font-weight:bold;
+  outline: none;
+  background-color: #fff;
+  border: 0;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+  color: #000;
+  height: 50px;
+  min-width: 50px;
+  -webkit-transition: background-color .2s ease-in;
+          transition: background-color .2s ease-in; }
+  .editor-toolbar li button:not(:disabled):hover{
+    background-color: #EEE;
+    color: #080;
+   }
 
-    .editor-toolbar li button:disabled {
-      cursor: default;
-    }
-
-    .editor-toolbar li button:focus-visible {
-      outline: 2px solid black;
-      outline-offset: 0;
-    }
+  .editor-toolbar li button:disabled {
+    cursor: default;
+  }
+  
+  .editor-toolbar li button:focus-visible,
+  .editor-blocktype-menu select:focus-visible {
+    border: 2px solid black;
+  }
 
   .editor-toolbar .editor-form-actions li:first-child button {
     border-bottom-left-radius: 5px;
@@ -4083,7 +4084,6 @@ height:auto;
   box-sizing: border-box;
   cursor: pointer;
   background-color: #fff;
-  border: none;
   transition: background-color .2s ease-in;
 }
 .editor-toolbar .editor-form-actions li.editor-dropdown-menu .editor-dropdown-trigger:hover,
@@ -4096,36 +4096,45 @@ height:auto;
   fill: #080;
 }
 
-.editor-blocktype-select {
-  height: 100%;
-  border: none !important;
-  border-right: 1px solid rgba(0, 0, 0, 0.1);
-  background: transparent;
-  font-family: inherit;
-  font-size: 0.85em;
-  font-weight: 600;
-  padding: 0 0.4em 0 0.75em;
-  cursor: pointer;
-  min-width: 7.5em;
-  border-radius: 10px 0 0 10px;
-  color: #111;
-  outline: none;
+.editor-toolbar .editor-form-actions .editor-blocktype-menu {
+padding:0 0.5em;
+
 }
-.editor-blocktype-select:hover,
-.editor-blocktype-select:focus {
+.editor-blocktype-menu:hover {
   background: #eee;
   color: #080;
 }
-.editor-blocktype-select option[value="h1"] { font-size: 1.3em; font-weight: 700; }
-.editor-blocktype-select option[value="h2"] { font-size: 1.15em; font-weight: 700; }
-.editor-blocktype-select option[value="h3"] { font-size: 1em; font-weight: 600; }
-.editor-blocktype-select option[value="p"]  { font-size: 0.85em; font-weight: 400; }
+.editor-blocktype-menu select:focus {
+  color:#080;
+}
+
+.editor-blocktype-menu select {
+  height: 100%;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  /* font-size: 0.85em; */
+  font-weight: 600;
+  padding: 0 0.5em;
+  cursor: pointer;
+  min-width: 7.5em;
+  border-radius: 0.25em 0 0 0.25em;
+  color: #111;
+  outline: none;
+}
+
+.editor-blocktype-select option[value="h1"] { font-size: 1.5em; font-weight: 700; }
+.editor-blocktype-select option[value="h2"] { font-size: 1.4em; font-weight: 700; }
+.editor-blocktype-select option[value="h3"] { font-size: 1.3em; font-weight: 600; }
+.editor-blocktype-select option[value="h4"] { font-size: 1.2em; font-weight: 600; }
+.editor-blocktype-select option[value="h5"] { font-size: 1em; font-weight: 600; }
+.editor-blocktype-select option[value="p"]  { font-size: 1em; font-weight: 400; }
 
 .editor-dropdown-panel {
   position: absolute;
   background: #fff;
   border: 1px solid rgba(0, 0, 0, 0.12);
-  border-radius: 8px;
+  border-radius: 0.5em;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14), 0 1px 4px rgba(0, 0, 0, 0.08);
   min-width: 220px;
   padding: 5px 0;
@@ -4136,23 +4145,16 @@ height:auto;
   color: #111;
 }
 
-.editor-dropdown-section-label {
-  padding: 0.55em 0.9em 0.25em;
-  font-weight: 700;
-  font-size: 0.75em;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #888;
+#editor-dropdown-panel-meta .editor-dropdown-section-label {
+  padding: 0.25em;
+  font-weight: bold;
+  color: #777;
   cursor: default;
   list-style: none;
   pointer-events: none;
-  border-top: 1px solid rgba(0,0,0,0.07);
-  margin-top: 3px;
-}
-.editor-dropdown-section-label:first-child {
   border-top: none;
   margin-top: 0;
-  padding: 1em;
+  padding: 0.5em 1em;
 }
 
 .editor-dropdown-panel li {
@@ -4164,9 +4166,10 @@ height:auto;
   width: 100%;
   height: max-content;
   text-align: left;
-  padding: 0.9em;
+  padding: 0.75em 1.25em;
   background: none;
-  border: none;
+  border-top: 1px solid #ccc;
+  box-shadow:none;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -4181,12 +4184,13 @@ height:auto;
   color: #060;
 }
 .editor-dropdown-item-label {
-  font-weight: 500;
+  font-weight: bold;
+  margin-bottom:0.5em;
+  color: #000;
 }
 .editor-dropdown-item-desc {
-  color: #777;
-  margin-top: 0.08em;
-  font-weight: normal;
+  color: #333;
+  line-height:1.2;
 }
 
 .editor-dropdown-panel li button.editor-dropdown-item.editor-dropdown-item-current {
@@ -4196,6 +4200,7 @@ height:auto;
   align-items: center;
   justify-content: space-between;
 }
+
 .editor-dropdown-item-current::after {
   content: '✓';
   font-size: 0.8em;
@@ -4205,8 +4210,8 @@ height:auto;
 }
 
 .editor-toolbar .editor-form-actions li button svg {
-  width: 15px;
-  height: 15px;
+  width: 1en;
+  height: 1em;
   fill: #111;
   flex-shrink: 0;
 }
@@ -4224,10 +4229,10 @@ height:auto;
   stroke: #080;
 }
 
-.editor-dropdown-panel li button.editor-dropdown-item.has-icon {
+.editor-dropdown-panel li button.editor-dropdown-item {
   flex-direction: row;
   align-items: flex-start;
-  gap: 0.55em;
+  gap: 1.25em;
 }
 .editor-dropdown-item-icon {
   flex-shrink: 0;
@@ -4237,16 +4242,14 @@ height:auto;
   display: flex;
   align-items: center;
 }
-.editor-dropdown-item-icon svg {
-  width: 20px;
-  height: 20px;
+button.editor-dropdown-item svg {
   fill: currentColor;
 }
 .editor-dropdown-item-text {
   display: flex;
   flex-direction: column;
 }
-.editor-dropdown-panel li button.editor-dropdown-item.has-icon:hover .editor-dropdown-item-icon {
+.editor-dropdown-panel li button.editor-dropdown-item:hover svg {
   color: #060;
 }
 
@@ -4257,19 +4260,14 @@ height:auto;
   box-sizing: border-box;
   white-space: nowrap;
   font-style: italic;
-  font-size: 0.8em;
-  padding: 0 12px;
-  opacity: 0.65;
-  border-left: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 0 0.5em;
+  /* opacity: 0.65; */
   background-color: #fff;
   cursor: pointer;
-  border-top: none;
-  border-right: none;
-  border-bottom: none;
   transition: background-color .2s ease-in, opacity .2s ease-in;
 }
 .editor-toolbar .editor-form-actions li.editor-mode-toggle .editor-mode-toggle-btn:hover {
-  opacity: 1;
+  /* opacity: 1; */
   background-color: #EEE;
   color: #080;
 }

--- a/media/css/dokieli.css
+++ b/media/css/dokieli.css
@@ -3972,6 +3972,7 @@ height:auto;
     font-weight:bold;
     background-color: #fff;
     border: 0;
+    outline: none;
     box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
     color: #000;
     height: 50px;
@@ -3981,15 +3982,16 @@ height:auto;
     .editor-toolbar li button:not(:disabled):hover{
       background-color: #EEE;
       color: #080; }
-      
+
     .editor-toolbar li button:disabled {
       cursor: default;
     }
 
-    .editor-toolbar li button:focus {
-      border: 2px solid black;
+    .editor-toolbar li button:focus-visible {
+      outline: 2px solid black;
+      outline-offset: 0;
     }
-  
+
   .editor-toolbar .editor-form-actions li:first-child button {
     border-bottom-left-radius: 5px;
     border-top-left-radius: 5px; }
@@ -4096,7 +4098,7 @@ height:auto;
 
 .editor-blocktype-select {
   height: 100%;
-  border: none;
+  border: none !important;
   border-right: 1px solid rgba(0, 0, 0, 0.1);
   background: transparent;
   font-family: inherit;
@@ -4162,7 +4164,7 @@ height:auto;
   width: 100%;
   height: max-content;
   text-align: left;
-  padding: 0.45em 0.9em;
+  padding: 0.9em;
   background: none;
   border: none;
   cursor: pointer;

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -264,7 +264,8 @@ export class Editor {
         // console.log(editorView);
 
         //TODO: 'math', 'sparkline',
-        this.authorToolbarView = new AuthorToolbar('author', ['p', 'h1', 'h2', 'h3', 'h4', 'em', 'strong', 'lang', 'a', 'img', 'ol', 'ul', 'pre', 'code', 'blockquote', 'q', 'semantics', 'citation', 'requirement', 'note'], editorView);
+        // Visible: strong, em, a. submenu (block type selector): p, h1-h4. submenu (+): img, ol, ul, pre, code, blockquote, q. submenu (···): semantics, citation, requirement, note, lang.
+        this.authorToolbarView = new AuthorToolbar('author', ['strong', 'em', 'a', 'p', 'h1', 'h2', 'h3', 'h4', 'img', 'ol', 'ul', 'pre', 'code', 'blockquote', 'q', 'semantics', 'citation', 'requirement', 'note', 'lang'], editorView);
 
         // Append DOM portion of toolbar to current editor.
         // editorView.dom.parentNode.appendChild(toolbarView.dom);
@@ -381,7 +382,8 @@ export class Editor {
   createSocialToolbar() {
     // Create and initialize the SocialToolbar only when in social mode
     // console.log("creating social toolbar")
-    this.socialToolbarView = new SocialToolbar('social', ['share', 'approve', 'disapprove', 'specificity', 'bookmark', 'comment']);
+    // Visible: approve, disapprove, comment, bookmark. submenu (···): share, specificity.
+    this.socialToolbarView = new SocialToolbar('social', ['approve', 'disapprove', 'comment', 'bookmark', 'share', 'specificity']);
     document.body.appendChild(this.socialToolbarView.dom); // idk why this is needed? or is it not?
     // console.log("SocialToolbar created. Mode:", this.mode);
   }

--- a/src/editor/schema/base.js
+++ b/src/editor/schema/base.js
@@ -72,7 +72,7 @@ function getAttributes (node) {
   if (headings.includes(nodeName)) {
     return {
       originalAttributes: attrs,
-      level: nodeName[1],
+      level: Number(nodeName[1]),
     }
   }
 

--- a/src/editor/toolbar/author/author.js
+++ b/src/editor/toolbar/author/author.js
@@ -375,18 +375,28 @@ TODO:
       this.blocktypeSelect.appendChild(option);
     });
 
-    // Save the ProseMirror state on mousedown, before the select steals focus
-    // and collapses the editor's DOM selection.
-    let _savedState = null;
+    // Save the PM selection on mousedown, before the select steals focus and
+    // collapses the editor's DOM selection. We save only the selection (not the
+    // full state) so it can be re-applied to the *current* view state in the
+    // change handler, avoiding stale-transaction issues.
+    let _savedSelection = null;
     this.blocktypeSelect.addEventListener('mousedown', () => {
-      _savedState = this.editorView?.state ?? null;
+      _savedSelection = this.editorView?.state?.selection ?? null;
     });
     this.blocktypeSelect.addEventListener('change', (e) => {
-      const state = _savedState ?? this.editorView?.state;
-      _savedState = null;
+      const savedSelection = _savedSelection;
+      _savedSelection = null;
       const command = this.toolbarCommands[e.target.value];
-      if (command && state && this.editorView) {
+      if (command && this.editorView) {
         e.target.blur();
+        // Re-apply the saved selection to the current state so the command
+        // always operates on a consistent (state, selection) pair.
+        let state = this.editorView.state;
+        if (savedSelection) {
+          const tr = state.tr.setSelection(savedSelection);
+          this.editorView.dispatch(tr);
+          state = this.editorView.state;
+        }
         command(state, this.editorView.dispatch, this.editorView);
         this.editorView.focus();
       }

--- a/src/editor/toolbar/author/author.js
+++ b/src/editor/toolbar/author/author.js
@@ -354,6 +354,7 @@ TODO:
       { label: 'Heading 1', value: 'h1' },
       { label: 'Heading 2', value: 'h2' },
       { label: 'Heading 3', value: 'h3' },
+      { label: 'Heading 4', value: 'h4' },
     ].forEach(({ label, value }) => {
       const option = document.createElement('option');
       option.value = value;
@@ -391,10 +392,12 @@ TODO:
 
   getBlockTypeKey(state) {
     const { $from } = state.selection;
-    const node = $from.parent;
+    let depth = $from.depth;
+    while (depth > 0 && !$from.node(depth).isTextblock) depth--;
+    const node = $from.node(depth);
     if (node.type === schema.nodes.heading) {
       const level = node.attrs.level;
-      if (level >= 1 && level <= 3) return `h${level}`;
+      if (level >= 1 && level <= 4) return `h${level}`;
     }
     return 'p';
   }
@@ -992,12 +995,17 @@ function toggleHeading(schema, level) {
     const { nodes } = schema;
     const { $from } = state.selection;
     const nodeType = nodes.heading;
-    
-    if ($from.node().type === nodeType && $from.node().attrs.level === level) {
+    let depth = $from.depth;
+    while (depth > 0 && !$from.node(depth).isTextblock) depth--;
+    const node = $from.node(depth);
+
+    if (node.type === nodeType && node.attrs.level === level) {
       return setBlockType(nodes.p)(state, dispatch);
-    }
-    else {
-      return setBlockType(nodeType, { level })(state, dispatch);
+    } else {
+      return setBlockType(nodeType, {
+        level,
+        originalAttributes: node.attrs.originalAttributes
+      })(state, dispatch);
     }
   };
 }

--- a/src/editor/toolbar/author/author.js
+++ b/src/editor/toolbar/author/author.js
@@ -299,7 +299,7 @@ TODO:
             icon: buttonIcons["semantics"]?.icon,
             label: "Define Semantics",
             description:
-              "Add attributes to describe selection meaning (e.g. about, property)",
+              "Add attributes to describe selection meaning",
             action: () => {
               this.dom.querySelector("#editor-button-semantics")?.click();
             },

--- a/src/editor/toolbar/author/author.js
+++ b/src/editor/toolbar/author/author.js
@@ -28,6 +28,7 @@ import Config from "../../../config.js";
 import { fragmentFromString } from "../../../utils/html.js";
 import { i18n } from "../../../i18n.js"
 import { htmlEncode, sanitizeInsertAdjacentHTML } from "../../../utils/sanitization.js";
+import { buttonIcons } from "../../../ui/buttons.js";
 
 const ns = Config.ns;
 
@@ -249,21 +250,101 @@ TODO:
     return toolbarPopups;
   }
 
+  getSubmenuButtons() {
+    return ['p', 'h1', 'h2', 'h3', 'h4', 'img', 'ul', 'ol', 'blockquote', 'q', 'pre', 'code', 'semantics', 'citation', 'requirement', 'note', 'lang'];
+  }
+
+  getModeToggle() {
+    return { label: 'Back to Reading', targetMode: 'social' };
+  }
+
+  getDropdownMenus() {
+    return {
+      plus: {
+        label: '+',
+        title: 'Insert',
+        items: [
+          { icon: buttonIcons['img']?.icon,        label: 'Image',         action: () => { this.dom.querySelector('#editor-button-img')?.click(); } },
+          // TODO: bring back when we re-implement lists
+          // { icon: buttonIcons['ul']?.icon,         label: 'Bullet List',   action: () => { this.dom.querySelector('#editor-button-ul')?.click(); } },
+          // { icon: buttonIcons['ol']?.icon,         label: 'Numbered List', action: () => { this.dom.querySelector('#editor-button-ol')?.click(); } },
+          { icon: buttonIcons['blockquote']?.icon, label: 'Quote',         action: () => { this.dom.querySelector('#editor-button-blockquote')?.click(); } },
+          { icon: buttonIcons['pre']?.icon,        label: 'Code Block',    action: () => { this.dom.querySelector('#editor-button-pre')?.click(); } },
+        ]
+      },
+      meta: {
+        label: '···',
+        title: 'More options',
+        sectionLabel: 'Metadata and Semantics',
+        items: [
+          { icon: buttonIcons['semantics']?.icon,   label: 'Define Semantics',  description: 'Add attributes to describe selection meaning (e.g. about, property)',    action: () => { this.dom.querySelector('#editor-button-semantics')?.click(); } },
+          { icon: buttonIcons['citation']?.icon,    label: 'Add Requirement', description: 'Link markup to a formal specification requirement',            action: () => { this.dom.querySelector('#editor-button-citation')?.click(); } },
+          { icon: buttonIcons['note']?.icon,        label: 'Note',   description: 'Add an internal note or footnote.',             action: () => { this.dom.querySelector('#editor-button-note')?.click(); } },
+          { icon: buttonIcons['lang']?.icon,        label: 'Set Language',                                                                           action: () => { this.dom.querySelector('#editor-button-lang')?.click(); } },
+          { icon: buttonIcons['requirement']?.icon, label: 'Add Requirement',                                                                        action: () => { this.dom.querySelector('#editor-button-requirement')?.click(); } },
+        ]
+      }
+    };
+  }
+
+  beforeButtons() {
+    const li = document.createElement('li');
+    li.className = 'editor-blocktype-menu';
+
+    this.blocktypeSelect = document.createElement('select');
+    this.blocktypeSelect.className = 'editor-blocktype-select';
+    this.blocktypeSelect.id = 'editor-blocktype-selector';
+    this.blocktypeSelect.setAttribute('title', 'Block type');
+
+    [
+      { label: 'Paragraph', value: 'p' },
+      { label: 'Heading 1', value: 'h1' },
+      { label: 'Heading 2', value: 'h2' },
+      { label: 'Heading 3', value: 'h3' },
+    ].forEach(({ label, value }) => {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = label;
+      this.blocktypeSelect.appendChild(option);
+    });
+
+    this.blocktypeSelect.addEventListener('change', (e) => {
+      const command = this.toolbarCommands[e.target.value];
+      if (command && this.editorView) {
+        command(this.editorView.state, this.editorView.dispatch, this.editorView);
+        this.editorView.focus();
+      }
+    });
+
+    li.appendChild(this.blocktypeSelect);
+    this.ul.appendChild(li);
+  }
+
   // Called when there is a state change, e.g., added something to the DOM or selection change.
   update(view) {
     this.selectionUpdate(view);
     const selection = window.getSelection();
     const isSelection = selection && !selection.isCollapsed;
-    // Hide the toolbar when there is no selection
     if (!isSelection) {
       if (this.dom.classList.contains('editor-form-active')) {
-        // this.dom.classList.remove("editor-form-active");
-        // console.log("selection update, cleanup toolbar")
         this.cleanupToolbar();
       }
       return;
     }
-  }  
+    if (this.blocktypeSelect && view) {
+      this.blocktypeSelect.value = this.getBlockTypeKey(view.state);
+    }
+  }
+
+  getBlockTypeKey(state) {
+    const { $from } = state.selection;
+    const node = $from.parent;
+    if (node.type === schema.nodes.heading) {
+      const level = node.attrs.level;
+      if (level >= 1 && level <= 3) return `h${level}`;
+    }
+    return 'p';
+  }
 
   updateToolbarVisibility(e) {
     // document.addEventListener('click', (e) => {

--- a/src/editor/toolbar/author/author.js
+++ b/src/editor/toolbar/author/author.js
@@ -271,14 +271,20 @@ TODO:
               this.dom.querySelector("#editor-button-img")?.click();
             },
           },
-          // TODO: bring back when we re-implement lists
-          // { icon: buttonIcons['ul']?.icon,         label: 'Bullet List',   action: () => { this.dom.querySelector('#editor-button-ul')?.click(); } },
-          // { icon: buttonIcons['ol']?.icon,         label: 'Numbered List', action: () => { this.dom.querySelector('#editor-button-ol')?.click(); } },
+          { icon: buttonIcons['ul']?.icon,         label: 'Bullet List',   action: () => { this.dom.querySelector('#editor-button-ul')?.click(); } },
+          { icon: buttonIcons['ol']?.icon,         label: 'Numbered List', action: () => { this.dom.querySelector('#editor-button-ol')?.click(); } },
           {
             icon: buttonIcons["blockquote"]?.icon,
-            label: "Quote",
+            label: "Blockquote",
             action: () => {
               this.dom.querySelector("#editor-button-blockquote")?.click();
+            },
+          },
+          {
+            icon: buttonIcons["q"]?.icon,
+            label: "Inline Quote",
+            action: () => {
+              this.dom.querySelector("#editor-button-q")?.click();
             },
           },
           {
@@ -286,6 +292,13 @@ TODO:
             label: "Code Block",
             action: () => {
               this.dom.querySelector("#editor-button-pre")?.click();
+            },
+          },
+          {
+            icon: buttonIcons["code"]?.icon,
+            label: "Inline Code",
+            action: () => {
+              this.dom.querySelector("#editor-button-code")?.click();
             },
           },
         ],
@@ -362,10 +375,19 @@ TODO:
       this.blocktypeSelect.appendChild(option);
     });
 
+    // Save the ProseMirror state on mousedown, before the select steals focus
+    // and collapses the editor's DOM selection.
+    let _savedState = null;
+    this.blocktypeSelect.addEventListener('mousedown', () => {
+      _savedState = this.editorView?.state ?? null;
+    });
     this.blocktypeSelect.addEventListener('change', (e) => {
+      const state = _savedState ?? this.editorView?.state;
+      _savedState = null;
       const command = this.toolbarCommands[e.target.value];
-      if (command && this.editorView) {
-        command(this.editorView.state, this.editorView.dispatch, this.editorView);
+      if (command && state && this.editorView) {
+        e.target.blur();
+        command(state, this.editorView.dispatch, this.editorView);
         this.editorView.focus();
       }
     });
@@ -999,12 +1021,14 @@ function toggleHeading(schema, level) {
     while (depth > 0 && !$from.node(depth).isTextblock) depth--;
     const node = $from.node(depth);
 
+    if (!node.isTextblock) return false;
+
     if (node.type === nodeType && node.attrs.level === level) {
       return setBlockType(nodes.p)(state, dispatch);
     } else {
       return setBlockType(nodeType, {
         level,
-        originalAttributes: node.attrs.originalAttributes
+        originalAttributes: node.attrs.originalAttributes || {}
       })(state, dispatch);
     }
   };

--- a/src/editor/toolbar/author/author.js
+++ b/src/editor/toolbar/author/author.js
@@ -304,15 +304,15 @@ TODO:
         ],
       },
       meta: {
-        label: "···",
+        label: "…",
         title: "More options",
-        sectionLabel: "Metadata and Semantics",
+        sectionLabel: "Structure and Semantics",
         items: [
           {
             icon: buttonIcons["semantics"]?.icon,
             label: "Define Semantics",
             description:
-              "Add attributes to describe selection meaning",
+              "Add attributes to describe the meaning of the selection.",
             action: () => {
               this.dom.querySelector("#editor-button-semantics")?.click();
             },
@@ -336,6 +336,7 @@ TODO:
           {
             icon: buttonIcons["lang"]?.icon,
             label: "Set Language",
+            description: "Set the language of the selection.",
             action: () => {
               this.dom.querySelector("#editor-button-lang")?.click();
             },
@@ -343,7 +344,7 @@ TODO:
           {
             icon: buttonIcons["requirement"]?.icon,
             label: "Add Requirement",
-            description: "Link markup to a formal specification requirement",
+            description: "Link the selection to a technical requirement.",
             action: () => {
               this.dom.querySelector("#editor-button-requirement")?.click();
             },
@@ -368,6 +369,7 @@ TODO:
       { label: 'Heading 2', value: 'h2' },
       { label: 'Heading 3', value: 'h3' },
       { label: 'Heading 4', value: 'h4' },
+      { label: 'Heading 5', value: 'h5' },
     ].forEach(({ label, value }) => {
       const option = document.createElement('option');
       option.value = value;

--- a/src/editor/toolbar/author/author.js
+++ b/src/editor/toolbar/author/author.js
@@ -261,29 +261,82 @@ TODO:
   getDropdownMenus() {
     return {
       plus: {
-        label: '+',
-        title: 'Insert',
+        label: "+",
+        title: "Insert",
         items: [
-          { icon: buttonIcons['img']?.icon,        label: 'Image',         action: () => { this.dom.querySelector('#editor-button-img')?.click(); } },
+          {
+            icon: buttonIcons["img"]?.icon,
+            label: "Image",
+            action: () => {
+              this.dom.querySelector("#editor-button-img")?.click();
+            },
+          },
           // TODO: bring back when we re-implement lists
           // { icon: buttonIcons['ul']?.icon,         label: 'Bullet List',   action: () => { this.dom.querySelector('#editor-button-ul')?.click(); } },
           // { icon: buttonIcons['ol']?.icon,         label: 'Numbered List', action: () => { this.dom.querySelector('#editor-button-ol')?.click(); } },
-          { icon: buttonIcons['blockquote']?.icon, label: 'Quote',         action: () => { this.dom.querySelector('#editor-button-blockquote')?.click(); } },
-          { icon: buttonIcons['pre']?.icon,        label: 'Code Block',    action: () => { this.dom.querySelector('#editor-button-pre')?.click(); } },
-        ]
+          {
+            icon: buttonIcons["blockquote"]?.icon,
+            label: "Quote",
+            action: () => {
+              this.dom.querySelector("#editor-button-blockquote")?.click();
+            },
+          },
+          {
+            icon: buttonIcons["pre"]?.icon,
+            label: "Code Block",
+            action: () => {
+              this.dom.querySelector("#editor-button-pre")?.click();
+            },
+          },
+        ],
       },
       meta: {
-        label: '···',
-        title: 'More options',
-        sectionLabel: 'Metadata and Semantics',
+        label: "···",
+        title: "More options",
+        sectionLabel: "Metadata and Semantics",
         items: [
-          { icon: buttonIcons['semantics']?.icon,   label: 'Define Semantics',  description: 'Add attributes to describe selection meaning (e.g. about, property)',    action: () => { this.dom.querySelector('#editor-button-semantics')?.click(); } },
-          { icon: buttonIcons['citation']?.icon,    label: 'Add Requirement', description: 'Link markup to a formal specification requirement',            action: () => { this.dom.querySelector('#editor-button-citation')?.click(); } },
-          { icon: buttonIcons['note']?.icon,        label: 'Note',   description: 'Add an internal note or footnote.',             action: () => { this.dom.querySelector('#editor-button-note')?.click(); } },
-          { icon: buttonIcons['lang']?.icon,        label: 'Set Language',                                                                           action: () => { this.dom.querySelector('#editor-button-lang')?.click(); } },
-          { icon: buttonIcons['requirement']?.icon, label: 'Add Requirement',                                                                        action: () => { this.dom.querySelector('#editor-button-requirement')?.click(); } },
-        ]
-      }
+          {
+            icon: buttonIcons["semantics"]?.icon,
+            label: "Define Semantics",
+            description:
+              "Add attributes to describe selection meaning (e.g. about, property)",
+            action: () => {
+              this.dom.querySelector("#editor-button-semantics")?.click();
+            },
+          },
+          {
+            icon: buttonIcons["citation"]?.icon,
+            label: "Add Citation",
+            description: "Add an inline citation for the selected text.",
+            action: () => {
+              this.dom.querySelector("#editor-button-citation")?.click();
+            },
+          },
+          {
+            icon: buttonIcons["note"]?.icon,
+            label: "Note",
+            description: "Add an internal note or footnote.",
+            action: () => {
+              this.dom.querySelector("#editor-button-note")?.click();
+            },
+          },
+          {
+            icon: buttonIcons["lang"]?.icon,
+            label: "Set Language",
+            action: () => {
+              this.dom.querySelector("#editor-button-lang")?.click();
+            },
+          },
+          {
+            icon: buttonIcons["requirement"]?.icon,
+            label: "Add Requirement",
+            description: "Link markup to a formal specification requirement",
+            action: () => {
+              this.dom.querySelector("#editor-button-requirement")?.click();
+            },
+          },
+        ],
+      },
     };
   }
 

--- a/src/editor/toolbar/social/social.js
+++ b/src/editor/toolbar/social/social.js
@@ -21,6 +21,7 @@ import Config from "../../../config.js";
 import { exportSelection, getSelectedParentElement, restoreSelection } from "../../utils/annotation.js";
 import { htmlEncode } from "../../../utils/sanitization.js";
 import { i18n } from "../../../i18n.js";
+import { buttonIcons } from "../../../ui/buttons.js";
 
 const ns = Config.ns;
 
@@ -38,6 +39,37 @@ export class SocialToolbar extends ToolbarView {
       // console.log('------HERE NOW: cleanupToolbar');
       this.cleanupToolbar();
     }
+  }
+
+  getSubmenuButtons() {
+    return ['share', 'specificity'];
+  }
+
+  getModeToggle() {
+    return { label: 'Switch to Edit', targetMode: 'author' };
+  }
+
+  getDropdownMenus() {
+    return {
+      more: {
+        label: '···',
+        title: 'More options',
+        items: [
+          {
+            icon: buttonIcons['share']?.icon,
+            label: 'Share Selection',
+            description: 'Share this selection with others',
+            action: () => { this.dom.querySelector('#editor-button-share')?.click(); }
+          },
+          {
+            icon: buttonIcons['specificity']?.icon,
+            label: 'Request Specificity',
+            description: 'Request to increase specificity on selected text',
+            action: () => { this.dom.querySelector('#editor-button-specificity')?.click(); }
+          }
+        ]
+      }
+    };
   }
 
   getToolbarButtonClickHandlers() {

--- a/src/editor/toolbar/social/social.js
+++ b/src/editor/toolbar/social/social.js
@@ -52,19 +52,19 @@ export class SocialToolbar extends ToolbarView {
   getDropdownMenus() {
     return {
       more: {
-        label: '···',
+        label: '…',
         title: 'More options',
         items: [
           {
             icon: buttonIcons['share']?.icon,
             label: 'Share Selection',
-            description: 'Share this selection with others',
+            description: 'Share this selection with others.',
             action: () => { this.dom.querySelector('#editor-button-share')?.click(); }
           },
           {
             icon: buttonIcons['specificity']?.icon,
             label: 'Request Specificity',
-            description: 'Request to increase specificity on selected text',
+            description: 'Request greater specificity for the selected text.',
             action: () => { this.dom.querySelector('#editor-button-specificity')?.click(); }
           }
         ]

--- a/src/editor/toolbar/toolbar.js
+++ b/src/editor/toolbar/toolbar.js
@@ -18,7 +18,7 @@ limitations under the License.
 import { schema } from "../schema/base.js"
 import { getButtonHTML } from "../../ui/buttons.js"
 import { getAnnotationInboxLocationHTML, getAnnotationLocationHTML, getClassesOfProductsConcepts, getDocument, getLanguageOptionsHTML, getLicenseOptionsHTML, getReferenceLabel } from "../../doc.js";
-import { getTextQuoteHTML, cloneSelection, setSelection, getSelectedParentElement } from "../utils/annotation.js";
+import { getTextQuoteHTML, cloneSelection, exportSelection, setSelection, getSelectedParentElement } from "../utils/annotation.js";
 import { escapeRegExp, matchAllIndex } from "../../util.js";
 import { fragmentFromString, getDocumentContentNode } from "../../utils/html.js";
 import { showUserIdentityInput } from "../../auth.js";
@@ -304,8 +304,8 @@ export class ToolbarView {
 
     var ul = document.querySelector('.editor-form-actions');
 
-    if (ul) { 
-      ul.parentNode.removeChild(ul); 
+    if (ul) {
+      ul.parentNode.removeChild(ul);
     }
 
     const toolbarForms = this.dom.getElementsByClassName('editor-form');
@@ -319,7 +319,174 @@ export class ToolbarView {
     this.dom.appendChild(this.ul);
     document.body.appendChild(this.dom);
 
-    this.initializeButtons(this.buttons)
+    this.beforeButtons();
+    this.initializeButtons(this.buttons);
+    this.afterButtons();
+  }
+
+  beforeButtons() {}
+
+  afterButtons() {
+    this.getSubmenuButtons().forEach(button => {
+      const li = this.dom.querySelector(`#editor-button-${button}`)?.closest('li');
+      if (li) li.classList.add('editor-submenu-button');
+    });
+
+    this.initializeDropdownMenus(this.getDropdownMenus());
+
+    const modeToggle = this.getModeToggle();
+    if (modeToggle) this.addModeToggleButton(modeToggle);
+  }
+
+  getSubmenuButtons() { return []; }
+
+  getDropdownMenus() { return {}; }
+
+  getModeToggle() { return null; }
+
+  initializeDropdownMenus(dropdowns) {
+    Object.entries(dropdowns).forEach(([name, config]) => {
+      const li = document.createElement('li');
+      li.className = 'editor-dropdown-menu';
+
+      const trigger = document.createElement('button');
+      trigger.id = `editor-dropdown-trigger-${name}`;
+      trigger.className = 'editor-dropdown-trigger';
+      trigger.type = 'button';
+      trigger.setAttribute('title', config.title || config.label);
+
+      const triggerLabel = document.createElement('span');
+      triggerLabel.textContent = config.label;
+      trigger.appendChild(triggerLabel);
+
+      const panel = document.createElement('ul');
+      panel.className = 'editor-dropdown-panel';
+      panel.id = `editor-dropdown-panel-${name}`;
+
+      if (config.sectionLabel) {
+        const sectionLi = document.createElement('li');
+        sectionLi.className = 'editor-dropdown-section-label';
+        sectionLi.textContent = config.sectionLabel;
+        panel.appendChild(sectionLi);
+      }
+
+      config.items.forEach(item => {
+        const itemLi = document.createElement('li');
+        const itemBtn = document.createElement('button');
+        itemBtn.type = 'button';
+        itemBtn.className = 'editor-dropdown-item';
+
+        if (item.icon) {
+          itemBtn.classList.add('has-icon');
+          const iconSpan = document.createElement('span');
+          iconSpan.className = 'editor-dropdown-item-icon';
+          iconSpan.setAttribute('aria-hidden', 'true');
+          iconSpan.innerHTML = item.icon;
+          itemBtn.appendChild(iconSpan);
+
+          const textSpan = document.createElement('span');
+          textSpan.className = 'editor-dropdown-item-text';
+          const labelSpan = document.createElement('span');
+          labelSpan.className = 'editor-dropdown-item-label';
+          labelSpan.textContent = item.label;
+          textSpan.appendChild(labelSpan);
+          if (item.description) {
+            const descSpan = document.createElement('span');
+            descSpan.className = 'editor-dropdown-item-desc';
+            descSpan.textContent = item.description;
+            textSpan.appendChild(descSpan);
+          }
+          itemBtn.appendChild(textSpan);
+        } else {
+          const labelSpan = document.createElement('span');
+          labelSpan.className = 'editor-dropdown-item-label';
+          labelSpan.textContent = item.label;
+          itemBtn.appendChild(labelSpan);
+          if (item.description) {
+            const descSpan = document.createElement('span');
+            descSpan.className = 'editor-dropdown-item-desc';
+            descSpan.textContent = item.description;
+            itemBtn.appendChild(descSpan);
+          }
+        }
+
+        itemBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          panel.classList.remove('editor-dropdown-panel-active');
+          trigger.classList.remove('editor-button-active');
+          item.action();
+        });
+
+        itemLi.appendChild(itemBtn);
+        panel.appendChild(itemLi);
+      });
+
+      trigger.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const isActive = panel.classList.contains('editor-dropdown-panel-active');
+        this.closeAllDropdowns();
+        if (!isActive) {
+          panel.classList.add('editor-dropdown-panel-active');
+          trigger.classList.add('editor-button-active');
+          this.positionDropdownPanel(trigger, panel);
+        }
+      });
+
+      li.appendChild(trigger);
+      this.ul.appendChild(li);
+      this.dom.appendChild(panel);
+    });
+  }
+
+  positionDropdownPanel(trigger, panel) {
+    const triggerRect = trigger.getBoundingClientRect();
+    const toolbarRect = this.dom.getBoundingClientRect();
+    let left = triggerRect.left - toolbarRect.left;
+    const maxLeft = toolbarRect.width - panel.offsetWidth;
+    panel.style.left = `${Math.max(0, Math.min(left, maxLeft))}px`;
+    panel.style.top = `${this.dom.offsetHeight}px`;
+  }
+
+  addModeToggleButton({ label, targetMode }) {
+    const li = document.createElement('li');
+    li.className = 'editor-mode-toggle';
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'editor-mode-toggle-btn';
+    btn.textContent = label;
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const sel = window.getSelection();
+      const containerNode = sel?.rangeCount ? getSelectedParentElement(sel.getRangeAt(0)) : null;
+      const selectionState = containerNode ? exportSelection(containerNode, sel) : null;
+      Config.Editor.toggleEditor(targetMode);
+      if (selectionState && containerNode) {
+        requestAnimationFrame(() => {
+          const newContainer = document.querySelector(`[id="${containerNode.id}"]`) ?? containerNode;
+          setSelection(selectionState.start, selectionState.end, newContainer);
+          const toolbarView = targetMode === 'author'
+            ? Config.Editor.authorToolbarView
+            : Config.Editor.socialToolbarView;
+          toolbarView?.selectionUpdate(null);
+        });
+      }
+    });
+
+    li.appendChild(btn);
+    this.ul.appendChild(li);
+  }
+
+  closeAllDropdowns() {
+    this.dom.querySelectorAll('.editor-dropdown-panel').forEach(p => {
+      p.classList.remove('editor-dropdown-panel-active');
+    });
+    this.dom.querySelectorAll('.editor-dropdown-trigger').forEach(t => {
+      t.classList.remove('editor-button-active');
+    });
   }
 
   getPopulateForms() {
@@ -330,9 +497,10 @@ export class ToolbarView {
     return;
   }
 
-  // hides toolbar, updates state of all buttons, hides and resets all forms. 
+  // hides toolbar, updates state of all buttons, hides and resets all forms.
   cleanupToolbar() {
     this.dom.classList.remove("editor-form-active");
+    this.closeAllDropdowns();
 
 // update buttons
     this.buttons.forEach(({button}) => {
@@ -421,6 +589,11 @@ export class ToolbarView {
       // Display the toolbar
       // TODO: do not change visibility if the selection is within a .do element (except the annotation maybe?)
       this.dom.classList.add("editor-form-active");
+
+      // sync block-type select with the current selection
+      if (this.blocktypeSelect && this.editorView && this.getBlockTypeKey) {
+        this.blocktypeSelect.value = this.getBlockTypeKey(this.editorView.state);
+      }
       
       this.dom.style.left = `${selectedPosition.left + (selectedPosition.width / 2 ) - (toolbarWidth / 2)}px`;
 

--- a/src/editor/toolbar/toolbar.js
+++ b/src/editor/toolbar/toolbar.js
@@ -18,7 +18,7 @@ limitations under the License.
 import { schema } from "../schema/base.js"
 import { getButtonHTML } from "../../ui/buttons.js"
 import { getAnnotationInboxLocationHTML, getAnnotationLocationHTML, getClassesOfProductsConcepts, getDocument, getLanguageOptionsHTML, getLicenseOptionsHTML, getReferenceLabel } from "../../doc.js";
-import { getTextQuoteHTML, cloneSelection, exportSelection, setSelection, getSelectedParentElement } from "../utils/annotation.js";
+import { getTextQuoteHTML, cloneSelection, exportSelection, restoreSelection, setSelection, getSelectedParentElement } from "../utils/annotation.js";
 import { escapeRegExp, matchAllIndex } from "../../util.js";
 import { fragmentFromString, getDocumentContentNode } from "../../utils/html.js";
 import { showUserIdentityInput } from "../../auth.js";
@@ -378,12 +378,7 @@ export class ToolbarView {
         itemBtn.className = 'editor-dropdown-item';
 
         if (item.icon) {
-          itemBtn.classList.add('has-icon');
-          const iconSpan = document.createElement('span');
-          iconSpan.className = 'editor-dropdown-item-icon';
-          iconSpan.setAttribute('aria-hidden', 'true');
-          iconSpan.innerHTML = item.icon;
-          itemBtn.appendChild(iconSpan);
+          itemBtn.appendChild(fragmentFromString(item.icon));
 
           const textSpan = document.createElement('span');
           textSpan.className = 'editor-dropdown-item-text';
@@ -474,6 +469,7 @@ export class ToolbarView {
       if (selectionState) {
         requestAnimationFrame(() => {
           setSelection(selectionState.start, selectionState.end, document.body);
+          // restoreSelection(this.selection);
           const toolbarView = targetMode === 'author'
             ? Config.Editor.authorToolbarView
             : Config.Editor.socialToolbarView;
@@ -593,8 +589,10 @@ export class ToolbarView {
       const toolbarWidth = this.dom.offsetWidth;
       const margin = 10;
 
-      const firstButton = this.dom.querySelector('button');
-      const shouldFocus = !!(!this.dom.classList.contains("editor-form-active") && firstButton !== document.activeElement);
+      const firstFocusable = this.dom.querySelector(
+        'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      const shouldFocus = !!(!this.dom.classList.contains("editor-form-active") && firstFocusable !== document.activeElement);
 
       // Display the toolbar
       // TODO: do not change visibility if the selection is within a .do element (except the annotation maybe?)
@@ -643,8 +641,11 @@ export class ToolbarView {
           event.preventDefault(); 
           const focusedButton = this.dom.querySelector('.editor-form-active');
 
-          if (!focusedButton) {
-            firstButton?.focus();
+          // if (!focusedButton) {
+          //   firstFocusable?.focus();
+          // }
+          if (shouldFocus && firstFocusable) {
+            firstFocusable.focus();
           }
 
           document.removeEventListener("keydown", handleTab);

--- a/src/editor/toolbar/toolbar.js
+++ b/src/editor/toolbar/toolbar.js
@@ -18,7 +18,7 @@ limitations under the License.
 import { schema } from "../schema/base.js"
 import { getButtonHTML } from "../../ui/buttons.js"
 import { getAnnotationInboxLocationHTML, getAnnotationLocationHTML, getClassesOfProductsConcepts, getDocument, getLanguageOptionsHTML, getLicenseOptionsHTML, getReferenceLabel } from "../../doc.js";
-import { getTextQuoteHTML, cloneSelection, exportSelection, restoreSelection, setSelection, getSelectedParentElement } from "../utils/annotation.js";
+import { getTextQuoteHTML, cloneSelection, setSelection, selectionToTextQuote, setSelectionFromTextQuote, getSelectedParentElement } from "../utils/annotation.js";
 import { escapeRegExp, matchAllIndex } from "../../util.js";
 import { fragmentFromString, getDocumentContentNode, selectArticleNode } from "../../utils/html.js";
 import { showUserIdentityInput } from "../../auth.js";
@@ -464,12 +464,12 @@ export class ToolbarView {
       e.stopPropagation();
       const sel = window.getSelection();
       const article = selectArticleNode(document);
-      const selectionState = (sel?.rangeCount && article) ? exportSelection(article, sel) : null;
+      const textQuote = (sel?.rangeCount && article) ? selectionToTextQuote(article, sel) : null;
       Config.Editor.toggleEditor(targetMode);
-      if (selectionState) {
+      if (textQuote) {
         requestAnimationFrame(() => {
           const newArticle = selectArticleNode(document);
-          if (newArticle) setSelection(selectionState.start, selectionState.end, newArticle);
+          if (newArticle) setSelectionFromTextQuote(newArticle, textQuote);
           const toolbarView = targetMode === 'author'
             ? Config.Editor.authorToolbarView
             : Config.Editor.socialToolbarView;

--- a/src/editor/toolbar/toolbar.js
+++ b/src/editor/toolbar/toolbar.js
@@ -20,7 +20,7 @@ import { getButtonHTML } from "../../ui/buttons.js"
 import { getAnnotationInboxLocationHTML, getAnnotationLocationHTML, getClassesOfProductsConcepts, getDocument, getLanguageOptionsHTML, getLicenseOptionsHTML, getReferenceLabel } from "../../doc.js";
 import { getTextQuoteHTML, cloneSelection, exportSelection, restoreSelection, setSelection, getSelectedParentElement } from "../utils/annotation.js";
 import { escapeRegExp, matchAllIndex } from "../../util.js";
-import { fragmentFromString, getDocumentContentNode } from "../../utils/html.js";
+import { fragmentFromString, getDocumentContentNode, selectArticleNode } from "../../utils/html.js";
 import { showUserIdentityInput } from "../../auth.js";
 import { getLinkRelation } from "../../graph.js";
 import Config from "../../config.js";
@@ -463,13 +463,13 @@ export class ToolbarView {
       e.preventDefault();
       e.stopPropagation();
       const sel = window.getSelection();
-      const body = document.body;
-      const selectionState = sel?.rangeCount ? exportSelection(body, sel) : null;
+      const article = selectArticleNode(document);
+      const selectionState = (sel?.rangeCount && article) ? exportSelection(article, sel) : null;
       Config.Editor.toggleEditor(targetMode);
       if (selectionState) {
         requestAnimationFrame(() => {
-          setSelection(selectionState.start, selectionState.end, document.body);
-          // restoreSelection(this.selection);
+          const newArticle = selectArticleNode(document);
+          if (newArticle) setSelection(selectionState.start, selectionState.end, newArticle);
           const toolbarView = targetMode === 'author'
             ? Config.Editor.authorToolbarView
             : Config.Editor.socialToolbarView;

--- a/src/editor/toolbar/toolbar.js
+++ b/src/editor/toolbar/toolbar.js
@@ -159,6 +159,7 @@ export class ToolbarView {
   }
 
   toggleButtonState(buttonNode, button, command) {
+      this.closeAllDropdowns();
       this.editorView?.focus();
       buttonNode.classList.toggle('editor-button-active');
 
@@ -410,6 +411,7 @@ export class ToolbarView {
           }
         }
 
+        itemBtn.addEventListener('mousedown', (e) => e.preventDefault());
         itemBtn.addEventListener('click', (e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -422,9 +424,13 @@ export class ToolbarView {
         panel.appendChild(itemLi);
       });
 
+      trigger.addEventListener('mousedown', (e) => e.preventDefault());
       trigger.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
+        if (document.activeElement && this.dom.contains(document.activeElement)) {
+          document.activeElement.blur();
+        }
         const isActive = panel.classList.contains('editor-dropdown-panel-active');
         this.closeAllDropdowns();
         if (!isActive) {
@@ -457,17 +463,17 @@ export class ToolbarView {
     btn.type = 'button';
     btn.className = 'editor-mode-toggle-btn';
     btn.textContent = label;
+    btn.addEventListener('mousedown', (e) => e.preventDefault());
     btn.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
       const sel = window.getSelection();
-      const containerNode = sel?.rangeCount ? getSelectedParentElement(sel.getRangeAt(0)) : null;
-      const selectionState = containerNode ? exportSelection(containerNode, sel) : null;
+      const body = document.body;
+      const selectionState = sel?.rangeCount ? exportSelection(body, sel) : null;
       Config.Editor.toggleEditor(targetMode);
-      if (selectionState && containerNode) {
+      if (selectionState) {
         requestAnimationFrame(() => {
-          const newContainer = document.querySelector(`[id="${containerNode.id}"]`) ?? containerNode;
-          setSelection(selectionState.start, selectionState.end, newContainer);
+          setSelection(selectionState.start, selectionState.end, document.body);
           const toolbarView = targetMode === 'author'
             ? Config.Editor.authorToolbarView
             : Config.Editor.socialToolbarView;
@@ -486,6 +492,10 @@ export class ToolbarView {
     });
     this.dom.querySelectorAll('.editor-dropdown-trigger').forEach(t => {
       t.classList.remove('editor-button-active');
+    });
+    // Also close any open popup forms
+    this.dom.querySelectorAll('.editor-form.editor-form-active').forEach(f => {
+      f.classList.remove('editor-form-active');
     });
   }
 

--- a/src/editor/utils/annotation.js
+++ b/src/editor/utils/annotation.js
@@ -518,3 +518,43 @@ export function setSelection(start, end, containerNode) {
   selection.removeAllRanges();
   selection.addRange(range);
 }
+
+const QUOTE_CONTEXT_LENGTH = 32;
+
+export function selectionToTextQuote(containerNode, selection) {
+  if (!selection.rangeCount) return null;
+  const range = selection.getRangeAt(0);
+  const exact = range.toString();
+
+  const preRange = document.createRange();
+  preRange.selectNodeContents(containerNode);
+  preRange.setEnd(range.startContainer, range.startOffset);
+  const prefix = preRange.toString().slice(-QUOTE_CONTEXT_LENGTH);
+
+  const postRange = document.createRange();
+  postRange.selectNodeContents(containerNode);
+  postRange.setStart(range.endContainer, range.endOffset);
+  const suffix = postRange.toString().slice(0, QUOTE_CONTEXT_LENGTH);
+
+  return { exact, prefix, suffix };
+}
+
+export function setSelectionFromTextQuote(containerNode, { exact, prefix, suffix }) {
+  const text = containerNode.textContent;
+  const search = (prefix || '') + exact + (suffix || '');
+
+  let start = -1;
+  if (search.length > 0) {
+    const idx = text.indexOf(search);
+    if (idx !== -1) start = idx + (prefix || '').length;
+  }
+
+  if (start === -1 && exact) {
+    start = text.indexOf(exact);
+  }
+
+  if (start === -1) return false;
+
+  setSelection(start, start + exact.length, containerNode);
+  return true;
+}


### PR DESCRIPTION
Initial pass at making the toolbars easier to use. This is essentially:

* reorganizing the toolbars with submenus for "advanced" features 
* add edit/reading button for author and social modes, so it's easier to toggle while working
