### PR TITLE
Fix #527: re-enable dialog trigger buttons when switching modes

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -169,6 +169,34 @@ export function hideDocumentMenu(e) {
   }
 
   removeNodesWithIds(Config.DocumentDoItems);
+
+  // When dialog nodes are removed (e.g., when switching modes), the close button
+  // handlers are never called, so re-enable the trigger buttons here.
+  // This fixes issue #527: buttons disabled when dialog is open stay disabled
+  // when dialog is closed for reasons other than clicking the close button.
+  const dialogTriggerButtons = {
+    'graph-view': '#document-views .resource-visualise',
+    'share-resource': '#document-do .resource-share',
+    'reply-to-resource': '#document-do .resource-reply',
+    'open-document': '#document-do .resource-open',
+    'source-view': '#document-do .resource-source',
+    'save-as-document': '#document-do .resource-save-as',
+    'embed-data-entry': '#document-do .embed-data-meta',
+    'generate-feed': '#document-do .generate-feed',
+    'robustify-links': '#document-do .robustify-links',
+    'message-log': '#document-do .message-log',
+    'delete-document': '#document-do .resource-delete',
+    'document-info': '#document-do .document-info',
+  };
+
+  Config.DocumentDoItems.forEach(id => {
+    const selector = dialogTriggerButtons[id];
+    if (!selector) return;
+    const btn = document.querySelector(selector);
+    if (btn) {
+      btn.disabled = false;
+    }
+  });
 }
 
 export function eventEscapeDocumentMenu(e) {


### PR DESCRIPTION
## Summary
Fixes #527 — Buttons disabled when dialog is open stay disabled when dialog is closed for other reasons (like switching modes).

## Problem
When a dialog is opened (e.g., share, graph view, reply, etc.), its trigger button is disabled via utton.disabled = true. When the dialog is closed by clicking the close button, the handler correctly re-enables the button via utton.disabled = false.

However, when the dialog is closed for other reasons — specifically when switching modes (author/social) — hideDocumentMenu() removes the dialog nodes via emoveNodesWithIds(Config.DocumentDoItems) **without** calling the close button handlers, leaving the trigger buttons stuck as disabled.

## Fix
In hideDocumentMenu() (in src/dialog.js), after calling emoveNodesWithIds(Config.DocumentDoItems), iterate over Config.DocumentDoItems and re-enable the corresponding trigger buttons for each dialog being removed.

\\\javascript
Config.DocumentDoItems.forEach(id => {
  const selector = dialogTriggerButtons[id];
  if (!selector) return;
  const btn = document.querySelector(selector);
  if (btn) {
    btn.disabled = false;
  }
});
\\\

This ensures that regardless of HOW a dialog is closed (via close button, via mode switch, or any other path through hideDocumentMenu()), the trigger button is always re-enabled.