### PR TITLE
Chore/remove shower

### DIFF
--- a/media/css/dokieli.css
+++ b/media/css/dokieli.css
@@ -4774,24 +4774,288 @@ font-size:2.25em;
   border-radius: 50%;
 }
 
-/* Shower CSS is updated to use .shower as parent selector to not conflict with dokieli and removed @page rule */
-/**
-  * Material theme for Shower HTML presentation engine
-  * shower-material v1.0.11, https://github.com/shower/material
-  * @copyright 2010-2017 Vadim Makeev, http://pepelsbey.net/
-  * @license MIT
-  */
-@charset "UTF-8";.shower,.shower *,.shower::after,.shower::before{box-sizing:border-box}.shower a,.shower abbr,.shower acronym,.shower address,.shower applet,.shower article,.shower aside,.shower audio,.shower b,.shower big,.shower blockquote,.shower body,.shower canvas,.shower caption,.shower center,.shower cite,.shower code,.shower dd,.shower del,.shower details,.shower dfn,.shower div,.shower dl,.shower dt,.shower em,.shower embed,.shower fieldset,.shower figcaption,.shower figure,.shower footer,.shower form:not(.editor-form),.shower h1,.shower h2,.shower h3,.shower h4,.shower h5,.shower h6,.shower header,.shower hgroup,.shower html,.shower i,.shower iframe,.shower img,.shower ins,.shower kbd,.shower label,.shower legend,.shower li,.shower mark,.shower menu,.shower nav,.shower object,.shower ol,.shower output,.shower p,.shower pre,.shower q,.shower ruby,.shower s,.shower samp,.shower section,.shower small,.shower span,.shower strike,.shower strong,.shower sub,.shower summary,.shower sup,.shower table,.shower tbody,.shower td,.shower tfoot,.shower th,.shower thead,.shower time,.shower tr,.shower tt,.shower u,.shower ul,.shower var,.shower video{margin:0;padding:0;border:0;font:inherit;vertical-align:baseline}.shower article,.shower aside,.shower details,.shower figcaption,.shower figure,.shower footer,.shower header,.shower hgroup,.shower main,.shower menu,.shower nav,.shower section{display:block}.shower .caption p,.shower body{line-height:1}.shower ol,.shower ul{list-style:none}.shower blockquote,.shower q{quotes:none}.shower blockquote::after,.shower blockquote::before,.shower q::after,.shower q::before{content:none}.shower table{border-collapse:collapse;border-spacing:0}.shower a{text-decoration:none}.shower{color:#212121;counter-reset:slide;font-family:'Ubuntu', system-ui, sans-serif;-webkit-print-color-adjust:exact;-webkit-text-size-adjust:none;-moz-text-size-adjust:none;-ms-text-size-adjust:none}.shower .caption{margin-top:-24px;font-size:24px;display:none;margin-bottom:1em;padding:1.02em 0 .9em 1em;width:100%;background:#4caf50 -webkit-linear-gradient(315deg,#4caf50 50%,#449e48 50%) no-repeat;background:#4caf50 linear-gradient(135deg,#4caf50 50%,#449e48 50%) no-repeat}@media (min-width:1168px){.shower .caption{margin-top:-48px;font-size:48px}}@media (min-width:2336px){.shower .caption{margin-top:-96px;font-size:96px}}.shower .caption h1{padding-bottom:.28em;color:#fff;font:1.17em/1 Roboto Light,sans-serif}.shower .caption p{color:#c9e7cb;font-size:.58em}.shower .caption a{color:inherit}.shower .slide{position:relative;z-index:1;overflow:hidden;padding:104px 112px 0 96px;width:1024px;height:640px;background:#fff;line-height:2;font-size:24px}.shower .slide::after{position:absolute;left:96px;bottom:48px;color:#bdbdbd;counter-increment:slide;content:counter(slide)}.shower .slide h2{margin-bottom:32px;color:#212121;font:48px/1 Roboto Light,sans-serif}.shower .slide p{margin-bottom:1em}.shower .slide p.note,.shower .slide pre .comment{color:#9e9e9e}.shower .slide a{background:-webkit-linear-gradient(bottom,currentColor .09em,transparent .09em) repeat-x;background:linear-gradient(to top,currentColor .09em,transparent .09em) repeat-x;color:#4caf50}.shower .slide b,.shower .slide strong{font-weight:700}.shower .slide blockquote,.shower .slide dfn,.shower .slide em,.shower .slide i{font-style:italic}.shower .slide code,.shower .slide kbd,.shower .slide mark,.shower .slide samp{padding:.1em .3em;background:#dbefdc}.shower .slide code,.shower .slide kbd,.shower .slide samp{line-height:1;font-family: 'Ubuntu Mono', ui-monospace, monospace;}.shower .slide sub,.shower .slide sup{position:relative;line-height:0;font-size:75%}.shower .slide sub{bottom:-.25em}.shower .slide sup{top:-.5em}.shower .slide blockquote::before{position:absolute;margin:-.04em 0 0 -.4em;color:#bdbdbd;line-height:1;font-style:normal;font-size:7em;content:'\201D'}.shower .slide blockquote+figcaption{margin:-1em 0 1em;font-style:italic;font-weight:700}.shower .slide ol,.shower .slide ul{margin-bottom:1em;counter-reset:list}.shower .slide ol li,.shower .slide ul li{break-inside:avoid;text-indent:-2em}.shower .slide ol li::before,.shower .slide ul li::before{display:inline-block;width:2em;color:#bdbdbd;text-align:right}.shower .slide ol ol,.shower .slide ol ul,.shower .slide ul ol,.shower .slide ul ul{margin-bottom:0;margin-left:2em}.shower .slide ul>li::before{padding-right:.5em;content:'â€¢'}.shower .slide ul>li:lang(ru)::before{content:'â€”'}.shower .slide ol>li::before{padding-right:.4em;counter-increment:list;content:counter(list) "."}.shower .slide ol>li[value]::before{content:attr(value) "."}.shower .slide ul>li[value]::before{content:attr(value)}.shower .slide table{margin-left:-96px;margin-bottom:1em;width:calc(100% + 96px + 112px)}.shower .slide table td:first-child,.shower .slide table th:first-child{padding-left:96px}.shower .slide table td:last-child,.shower .slide table th:last-child{padding-right:96px}.shower .slide table th{text-align:left;font-weight:700}.shower .slide table tr:not(:last-of-type)>*{background:-webkit-linear-gradient(bottom,#bdbdbd .055em,transparent .055em) repeat-x;background:linear-gradient(to top,#bdbdbd .055em,transparent .055em) repeat-x}.shower .slide table.striped tr:nth-child(even){background:#edf7ee}.shower .slide table.striped tr>*{background-image:none}.shower .slide pre{margin-bottom:1em;counter-reset:code;white-space:normal}.shower .slide pre code{display:block;margin-left:-96px;padding:0 0 0 96px;width:calc(100% + 96px + 112px);background:0 0;line-height:2;white-space:pre;-moz-tab-size:4;-o-tab-size:4;tab-size:4}.shower .slide pre code:not(:only-child).mark{background:#edf7ee}.shower .slide pre code:not(:only-child)::before{position:absolute;margin-left:-2em;color:#bdbdbd;counter-increment:code;content:counter(code,decimal-leading-zero) "."}.shower .slide pre mark{position:relative;z-index:-1;margin:0 -.3em}.shower .slide pre mark.important{background:#4caf50;color:#fff}.shower .progress,.shower .slide footer{position:absolute;left:0;z-index:1;display:none}.shower .slide footer{right:0;padding:2em 112px 1em 96px;background:#edf7ee;bottom:-640px;-webkit-transition:bottom .3s;transition:bottom .3s}.shower .slide:hover>footer{bottom:0}.shower .slide.grid{background-image:url(../images/grid.png);-ms-interpolation-mode:nearest-neighbor;image-rendering:-webkit-optimize-contrast;image-rendering:-moz-crisp-edges;image-rendering:pixelated}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.shower .slide.grid{background-image:url(../images/grid@2x.png);background-size:1024px auto}}.shower .slide.black{background-color:#000}.shower .slide.black::after,.shower .slide.white::after{visibility:hidden}.shower .slide.white{background-color:#fff}.shower .slide .double,.shower .slide .triple{-webkit-column-gap:48px;-moz-column-gap:48px;column-gap:48px;-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto}.shower .slide .double{-webkit-column-count:2;-moz-column-count:2;column-count:2}.shower .slide .triple{-webkit-column-count:3;-moz-column-count:3;column-count:3}.shower .slide .shout{position:absolute;top:50%;left:0;z-index:1;padding-left:96px;width:100%;color:#fff;line-height:1.1;font-size:112px;-webkit-transform:translateY(-50%);transform:translateY(-50%)}.shower .slide .shout a{background:-webkit-linear-gradient(bottom,currentColor .06em,transparent .06em) repeat-x;background:linear-gradient(to top,currentColor .06em,transparent .06em) repeat-x;color:inherit}.shower .slide .shout::after{position:absolute;top:-555%;right:0;bottom:-555%;left:0;z-index:-1;background:#4caf50 -webkit-linear-gradient(315deg,#4caf50 50%,#449e48 50%) no-repeat;background:#4caf50 linear-gradient(135deg,#4caf50 50%,#449e48 50%) no-repeat;content:''}.shower .slide .cover{z-index:-1;max-width:100%;max-height:100%}.shower .slide .cover.w,.shower .slide .cover.width{width:100%;max-height:none}.shower .slide .cover.h,.shower .slide .cover.height{height:100%;max-width:none}.shower .slide .cover+figcaption{position:absolute;bottom:20px;right:10px;font-size:12px;opacity:.7;-webkit-transform-origin:0 100%;transform-origin:0 100%;-webkit-transform:translateX(100%) rotate(-90deg);transform:translateX(100%) rotate(-90deg)}.shower .slide .cover+figcaption.white{color:#fff}.shower .slide .cover+figcaption a{color:currentcolor}.shower .slide .cover,.shower .slide .place{position:absolute;top:50%;left:50%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)}.shower .slide .place.b.l,.shower .slide .place.b.r,.shower .slide .place.bottom.left,.shower .slide .place.bottom.right,.shower .slide .place.t.l,.shower .slide .place.t.r,.shower .slide .place.top.left,.shower .slide .place.top.right{-webkit-transform:none;transform:none}.shower .slide .place.b,.shower .slide .place.bottom,.shower .slide .place.t,.shower .slide .place.top{-webkit-transform:translate(-50%,0);transform:translate(-50%,0)}.shower .slide .place.l,.shower .slide .place.left,.shower .slide .place.r,.shower .slide .place.right{-webkit-transform:translate(0,-50%);transform:translate(0,-50%)}.shower .slide .place.t,.shower .slide .place.t.r,.shower .slide .place.top,.shower .slide .place.top.left,.shower .slide .place.top.right{top:0}.shower .slide .place.r,.shower .slide .place.right{right:0;left:auto}.shower .slide .place.b,.shower .slide .place.b.l,.shower .slide .place.b.r,.shower .slide .place.bottom,.shower .slide .place.bottom.left,.shower .slide .place.bottom.right{top:auto;bottom:0}.shower .slide .place.l,.shower .slide .place.left{left:0}.shower .progress{bottom:0;height:8px;background:#4caf50;-webkit-transition:width .2s linear;transition:width .2s linear;clip:rect(0 1024px 8px 0);box-shadow:512px 0 0 512px #bdbdbd}.shower .badge{font-size:12px;display:none;padding:.5em 0 2em;width:100%}@media (min-width:1168px){.shower .badge{font-size:24px}}@media (min-width:2336px){.shower .badge{font-size:48px}}.shower .badge a{display:inline-block;margin-left:9em;padding-left:4em;color:#9e9e9e}.shower .badge svg{position:absolute;margin:-1.1em 0 0 -4.5em;width:4em;height:4em;fill:currentColor}.shower .region{display:none}@media screen{/*.shower.list*//*XXX: dokieli experimental:*/.shower > main > article{padding-top:24px;width:100%;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;background:#eee;position:absolute;clip:rect(0,auto,auto,0)}}@media screen and (min-width:1168px){.shower.list{padding-top:48px}}@media screen and (min-width:2336px){.shower.list{padding-top:96px}}@media screen{.shower.list .caption{display:block}.shower.list .slide{-webkit-transform-origin:0 0;transform-origin:0 0;margin:0 -768px -456px 24px;-webkit-transform:scale(.25);transform:scale(.25);border-radius:2px;box-shadow:0 12px 4px -8px rgba(0,0,0,.2),0 12px 4px -8px rgba(0,0,0,.14),0 4px 20px 0 rgba(0,0,0,.12)}}@media screen and (min-width:1168px){.shower.list .slide{margin:0 -512px -272px 48px;-webkit-transform:scale(.5);transform:scale(.5)}}@media screen and (min-width:2336px){.shower.list .slide{margin:0 0 96px 96px;-webkit-transform:scale(1);transform:scale(1)}}@media screen{.shower.list .slide:hover{box-shadow:0 16px 20px 0 rgba(0,0,0,.2),0 4px 40px 0 rgba(0,0,0,.14),0 8px 16px -4px rgba(0,0,0,.12)}.shower.list .slide.active{box-shadow:0 32px 40px 4px rgba(0,0,0,.2),0 12px 56px 8px rgba(0,0,0,.14),0 20px 20px -12px rgba(0,0,0,.12)}}@media screen and (min-width:1168px){.shower.list .slide{border-radius:4px;box-shadow:0 6px 2px -4px rgba(0,0,0,.2),0 6px 2px -4px rgba(0,0,0,.14),0 2px 10px 0 rgba(0,0,0,.12)}.shower.list .slide:hover{box-shadow:0 8px 10px 0 rgba(0,0,0,.2),0 2px 20px 0 rgba(0,0,0,.14),0 8px 4px -2px rgba(0,0,0,.12)}.shower.list .slide.active{box-shadow:0 16px 20px 2px rgba(0,0,0,.2),0 6px 28px 4px rgba(0,0,0,.14),0 10px 10px -6px rgba(0,0,0,.12)}}@media screen and (min-width:2336px){.shower.list .slide{border-radius:8px;box-shadow:0 3px 1px -2px rgba(0,0,0,.2),0 3px 1px -2px rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12)}.shower.list .slide:hover{box-shadow:0 4px 5px 0 rgba(0,0,0,.2),0 1px 10px 0 rgba(0,0,0,.14),0 2px 4px -1px rgba(0,0,0,.12)}.shower.list .slide.active{box-shadow:0 8px 10px 1px rgba(0,0,0,.2),0 3px 14px 2px rgba(0,0,0,.14),0 5px 5px -3px rgba(0,0,0,.12)}}@media screen{.shower.list .badge,.shower.list .slide footer{display:block}.shower.full{position:absolute;top:50%;left:50%;overflow:hidden;margin:-320px 0 0 -512px;width:1024px;height:640px;background:#000}.shower.full .slide{position:absolute;top:0;left:0;margin-left:-150%;visibility:hidden}.shower.full .slide.active{margin:0;visibility:visible}.shower.full .slide pre code:not(:only-child).mark.next{visibility:visible;background:0 0}.shower.full .slide pre code:not(:only-child).mark.next.active{background:#edf7ee}.shower.full .slide .next{visibility:hidden}.shower.full .slide .next.active{visibility:visible}.shower.full .slide .shout::after{background-position:1024px 0;-webkit-transition:background-position .4s ease-out;transition:background-position .4s ease-out}.shower.full .slide.active .shout::after{background-position:0 0}.shower.full .progress{display:block}.shower.full .region{position:absolute;clip:rect(0 0 0 0);overflow:hidden;margin:-1px;padding:0;width:1px;height:1px;border:none;display:block}}
+/* Slideshow CSS, originally derived from shower-material v1.0.11 (MIT,
+   (c) 2010-2017 Vadim Makeev), heavily trimmed and rewritten for dokieli. */
 
-/*@media print {
+.shower,
+.shower *,
+.shower::after,
+.shower::before {
+  box-sizing: border-box;
+}
+
+/* Reset for elements inside slides so dokieli's body styles don't leak in. */
+.shower section, .shower header, .shower main, .shower article, .shower aside,
+.shower nav, .shower footer, .shower div, .shower span,
+.shower p, .shower h1, .shower h2, .shower h3, .shower h4, .shower h5, .shower h6,
+.shower ul, .shower ol, .shower li, .shower dl, .shower dt, .shower dd,
+.shower blockquote, .shower q, .shower table, .shower thead, .shower tbody,
+.shower tr, .shower th, .shower td, .shower caption,
+.shower pre, .shower code, .shower kbd, .shower samp,
+.shower figure, .shower figcaption, .shower address, .shower details, .shower summary,
+.shower a, .shower em, .shower i, .shower b, .shower strong, .shower cite,
+.shower mark, .shower sub, .shower sup, .shower abbr, .shower time,
+.shower img, .shower video, .shower iframe, .shower object {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+.shower article, .shower aside, .shower details, .shower figcaption,
+.shower figure, .shower footer, .shower header, .shower main,
+.shower nav, .shower section { display: block; }
+.shower a { text-decoration: none; }
+.shower table { border-collapse: collapse; border-spacing: 0; }
+.shower ul, .shower ol { list-style: none; }
+.shower blockquote, .shower q { quotes: none; }
+
+.shower {
+  color: #212121;
+  font-family: 'Ubuntu', system-ui, sans-serif;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+  text-size-adjust: none;
+}
+
+/* Slideshow caption header (above the list of slides). */
+.shower .caption {
+  display: none;
+  margin-bottom: 1em;
+  padding: 1em;
+  width: 100%;
+}
+.shower .caption h1 { color: #212121; }
+.shower .caption a { color: inherit; }
+
+/* Slide canvas: 1024x640 reference geometry; scaled by .list/.full. */
 .shower .slide {
-break-after:always;
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  padding: 104px 112px 0 96px;
+  width: 1024px;
+  height: 640px;
+  background: #fff;
+  line-height: 2;
+  font-size: 24px;
 }
-.shower .caption,
+.shower .slide h2 {
+  margin-bottom: 32px;
+  color: #212121;
+  font: 48px/1 'Roboto Light', sans-serif;
+}
+.shower .slide p { margin-bottom: 1em; }
+.shower .slide a {
+  background: linear-gradient(to top, currentColor .09em, transparent .09em) repeat-x;
+  color: #4caf50;
+}
+.shower .slide b, .shower .slide strong { font-weight: 700; }
+.shower .slide blockquote, .shower .slide dfn,
+.shower .slide em, .shower .slide i { font-style: italic; }
+.shower .slide code, .shower .slide kbd,
+.shower .slide mark, .shower .slide samp {
+  padding: .1em .3em;
+  background: #dbefdc;
+}
+.shower .slide code, .shower .slide kbd, .shower .slide samp {
+  line-height: 1;
+  font-family: 'Ubuntu Mono', ui-monospace, monospace;
+}
+.shower .slide sub, .shower .slide sup {
+  position: relative;
+  line-height: 0;
+  font-size: 75%;
+}
+.shower .slide sub { bottom: -.25em; }
+.shower .slide sup { top: -.5em; }
+.shower .slide blockquote + figcaption {
+  margin: -1em 0 1em;
+  font-style: italic;
+  font-weight: 700;
+}
+.shower .slide ol, .shower .slide ul { margin-bottom: 1em; }
+.shower .slide ol ol, .shower .slide ol ul,
+.shower .slide ul ol, .shower .slide ul ul {
+  margin-bottom: 0;
+  margin-left: 2em;
+}
+.shower .slide table {
+  margin-left: -96px;
+  margin-bottom: 1em;
+  width: calc(100% + 96px + 112px);
+}
+.shower .slide table td:first-child,
+.shower .slide table th:first-child { padding-left: 96px; }
+.shower .slide table td:last-child,
+.shower .slide table th:last-child { padding-right: 112px; }
+.shower .slide table th { text-align: left; font-weight: 700; }
+.shower .slide table tr:not(:last-of-type) > * {
+  background: linear-gradient(to top, #bdbdbd .055em, transparent .055em) repeat-x;
+}
+.shower .slide pre { margin-bottom: 1em; white-space: normal; }
+.shower .slide pre code {
+  display: block;
+  margin-left: -96px;
+  padding: 0 0 0 96px;
+  width: calc(100% + 96px + 112px);
+  background: 0 0;
+  line-height: 2;
+  white-space: pre;
+  tab-size: 4;
+}
+
+/* Slide-number badge: opt-in via .shower.numbered (toggle button). */
+.shower.numbered { counter-reset: slide; }
+.shower.numbered .slide::after {
+  position: absolute;
+  left: 96px;
+  bottom: 48px;
+  color: #bdbdbd;
+  counter-increment: slide;
+  content: counter(slide);
+}
+
+/* Slide footer: hidden in full mode, shown on hover in list. */
+.shower .progress,
+.shower .slide footer {
+  position: absolute;
+  left: 0;
+  z-index: 1;
+  display: none;
+}
+.shower .slide footer {
+  right: 0;
+  padding: 2em 112px 1em 96px;
+  background: #edf7ee;
+  bottom: -640px;
+  transition: bottom .3s;
+}
+.shower .slide:hover > footer { bottom: 0; }
+
+/* Shout: oversized centered title on green diagonal background. */
+.shower .slide .shout {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  z-index: 1;
+  padding-left: 96px;
+  width: 100%;
+  color: #fff;
+  line-height: 1.1;
+  font-size: 112px;
+  transform: translateY(-50%);
+}
+.shower .slide .shout a {
+  background: linear-gradient(to top, currentColor .06em, transparent .06em) repeat-x;
+  color: inherit;
+}
 .shower .slide .shout::after {
-background:none !important;
+  position: absolute;
+  top: -555%;
+  right: 0;
+  bottom: -555%;
+  left: 0;
+  z-index: -1;
+  background: #4caf50 linear-gradient(135deg, #4caf50 50%, #449e48 50%) no-repeat;
+  content: '';
 }
-}*/
+
+/* Cover: full-bleed background image. */
+.shower .slide .cover {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: -1;
+  max-width: 100%;
+  max-height: 100%;
+  transform: translate(-50%, -50%);
+}
+.shower .slide .cover.w,
+.shower .slide .cover.width { width: 100%; max-height: none; }
+.shower .slide .cover.h,
+.shower .slide .cover.height { height: 100%; max-width: none; }
+
+/* Progress bar (visible in full mode only). */
+.shower .progress {
+  bottom: 0;
+  height: 8px;
+  background: #4caf50;
+  transition: width .2s linear;
+}
+
+/* List view: tile slides into a flex grid. */
+@media screen {
+  .shower > main > article {
+    padding-top: 24px;
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    background: #eee;
+  }
+  .shower.list .caption { display: block; }
+  .shower.list .slide {
+    transform-origin: 0 0;
+    margin: 0 -768px -456px 24px;
+    transform: scale(.25);
+    border-radius: 2px;
+    box-shadow: 0 12px 4px -8px rgba(0,0,0,.2),
+                0 12px 4px -8px rgba(0,0,0,.14),
+                0 4px 20px 0 rgba(0,0,0,.12);
+  }
+  .shower.list .slide:hover {
+    box-shadow: 0 16px 20px 0 rgba(0,0,0,.2),
+                0 4px 40px 0 rgba(0,0,0,.14),
+                0 8px 16px -4px rgba(0,0,0,.12);
+  }
+  .shower.list .slide.active {
+    box-shadow: 0 32px 40px 4px rgba(0,0,0,.2),
+                0 12px 56px 8px rgba(0,0,0,.14),
+                0 20px 20px -12px rgba(0,0,0,.12);
+  }
+  .shower.list .slide footer { display: block; }
+}
+@media screen and (min-width: 1168px) {
+  .shower.list .slide {
+    margin: 0 -512px -272px 48px;
+    transform: scale(.5);
+    border-radius: 4px;
+  }
+}
+@media screen and (min-width: 2336px) {
+  .shower.list .slide {
+    margin: 0 0 96px 96px;
+    transform: scale(1);
+    border-radius: 8px;
+  }
+}
+
+/* Full view: one slide centered in the viewport. */
+.shower.full {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  overflow: hidden;
+  margin: -320px 0 0 -512px;
+  width: 1024px;
+  height: 640px;
+  background: #000;
+}
+.shower.full .slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin-left: -150%;
+  visibility: hidden;
+}
+.shower.full .slide.active { margin: 0; visibility: visible; }
+.shower.full .slide .shout::after {
+  background-position: 1024px 0;
+  transition: background-position .4s ease-out;
+}
+.shower.full .slide.active .shout::after { background-position: 0 0; }
+.shower.full .progress { display: block; }
 
 .shower.list .slide {
 overflow:auto;
@@ -4880,13 +5144,6 @@ margin-bottom:0;
 .shower .slide ul>li {
 text-indent: 0;
 }
-.shower .slide ol>li::before,
-.shower .slide ul>li::before {
-content: "";
-padding: 0;
-display: initial;
-width: auto;
-}
 .shower .slide p {
 margin-bottom: 0.5em;
 color:initial;
@@ -4900,12 +5157,6 @@ color: #080;
 .shower .progress {
 background: #080;
 }
-.shower .slide blockquote:before {
-font-size:5em;
-}
-/* .shower .slide blockquote footer {
-position:static;
-} */
 .shower header details summary {
 background-color:initial;
 }
@@ -4959,9 +5210,6 @@ clear:both;
 }
 .shower .slide footer dd figure p {
 margin-top: -2em;
-}
-.shower .slide blockquote::before {
-margin-left: -0.5em;
 }
 .shower .slide address {
 line-height: 1.3;
@@ -5057,10 +5305,6 @@ line-height: 1.6;
 margin-top: 0;
 margin-bottom: 0;
 line-height: 1.5;
-}
-.shower .slide:after {
-position: static;
-content: "";
 }
 .shower .slide .rfc2119 {
 text-transform: lowercase;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@shower/core": "3.3.0",
     "@uvdsl/solid-oidc-client-browser": "^0.2.2",
     "buffer": "^6.0.3",
     "d3-force": "^3.0.0",

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -162,8 +162,11 @@ export function hideDocumentMenu(e) {
   // document.removeEventListener('click', eventLeaveDocumentMenu);
 
   var dMenu = document.querySelector('#document-menu.do');
+  if (!dMenu) return;
   var dMenuButton = dMenu.querySelector('button');
-  dMenuButton.parentNode.replaceChild(fragmentFromString(Config.Button.Menu.OpenMenu), dMenuButton);
+  if (dMenuButton) {
+    dMenuButton.parentNode.replaceChild(fragmentFromString(Config.Button.Menu.OpenMenu), dMenuButton);
+  }
 
   dMenu.classList.remove('on');
   // var sections = dMenu.querySelectorAll('section');
@@ -3083,15 +3086,14 @@ export function createNewSlideshow(e) {
 }
 
 let _slideshowInteractionInit = false;
-let _showerInstance = null;
+let _slideshow = null;
 
-export function initSlideshowInteraction(showerInstance) {
-  if (showerInstance) _showerInstance = showerInstance;
+export function initSlideshowInteraction(slideshow) {
+  if (slideshow) _slideshow = slideshow;
 
   if (_slideshowInteractionInit) return;
   _slideshowInteractionInit = true;
 
-  // Capture phase so we run before shower's per-slide click handler (which checks defaultPrevented).
   document.addEventListener('click', (e) => {
     if (!document.body.classList.contains('shower')) return;
     if (!document.body.classList.contains('list')) return;
@@ -3110,27 +3112,18 @@ export function initSlideshowInteraction(showerInstance) {
     }
 
     e.preventDefault();
-    if (_showerInstance) {
-      const slides = Array.from(document.querySelectorAll('.shower .slide'));
-      const idx = slides.indexOf(slide);
-      _showerInstance.goTo(idx);
-      _showerInstance.enterFullMode();
+    const slides = Array.from(document.querySelectorAll('.shower .slide'));
+    const idx = slides.indexOf(slide);
+    if (_slideshow) {
+      _slideshow.goTo(idx);
+      _slideshow.enterFullMode();
     } else {
-      document.querySelectorAll('.shower .slide').forEach(s => s.classList.remove('active'));
+      slides.forEach(s => s.classList.remove('active'));
       slide.classList.add('active');
       document.body.classList.remove('list');
       document.body.classList.add('full');
     }
   }, true);
-
-  document.addEventListener('keydown', (e) => {
-    if (e.key !== 'Escape') return;
-    if (!document.body.classList.contains('shower')) return;
-    if (!document.body.classList.contains('full')) return;
-    if (_showerInstance) return;
-    document.body.classList.remove('full');
-    document.body.classList.add('list');
-  });
 }
 
 export function updateSlideshowAddButton() {

--- a/src/doc.js
+++ b/src/doc.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import rdf from "rdf-ext";
-import shower from '@shower/core';
+import * as Slideshow from './slideshow.js';
 import { diffChars } from 'diff';
 import LinkHeader from "http-link-header";
 import Config from './config.js'
@@ -3735,7 +3735,7 @@ export function initCurrentStylesheet(e) {
     var toc = document.getElementById('table-of-contents');
     toc = (toc) ? toc.parentNode.removeChild(toc) : false;
 
-    shower.initRun();
+    Slideshow.start();
   }
 
   if (currentStylesheet.toLowerCase() == 'shower') {
@@ -3750,7 +3750,7 @@ export function initCurrentStylesheet(e) {
 
     history.pushState(null, null, window.location.pathname);
 
-    shower.removeEvents();
+    Slideshow.stop();
   }
 }
 

--- a/src/init.js
+++ b/src/init.js
@@ -31,11 +31,11 @@ import { getProxyableIRI, getUrlParams, stripFragmentFromString, stripUrlSearchH
 import { SolidStorage, GitForgeStorage, initStorage } from './storage/backend.js';
 import { initEditor } from './editor/initEditor.js';
 import { showGraph, showVisualisationGraph } from './viz.js';
-import shower from '@shower/core';
+import * as Slideshow from './slideshow.js';
 import { openResource, initDocumentMenu, spawnDokieli, showDocumentMenu, initSlideshowInteraction } from './dialog.js';
 import { Icon } from './ui/icons.js';
 import { eventButtonClose, eventButtonSignIn, eventButtonSignOut, eventButtonNotificationsToggle, eventButtonInfo, emitDocEvent } from './events.js';
-import { hasNonWhitespaceText, getDocumentContentNode, selectArticleNode, fragmentFromString } from "./utils/html.js";
+import { hasNonWhitespaceText, getDocumentContentNode, selectArticleNode } from "./utils/html.js";
 
 export async function init (url) {
   initServiceWorker();
@@ -348,127 +348,20 @@ export async function initDocumentMode(mode) {
   // }
 }
 
-let showerInstance = null;
-let showerExternalListeners = [];
-let showerHistoryRestore = null;
-
-const DOKIELI_HASH_PARAMS = ['author', 'graph', 'graph-view', 'open', 'output', 'social', 'style'];
-
-// Drop shower's slide-id URL writes when a dokieli hash param like #open=URL is set.
-function patchHistoryForShower() {
-  const origReplace = history.replaceState.bind(history);
-  const origPush = history.pushState.bind(history);
-
-  const hasDokieliHashParam = () => {
-    const hash = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : '';
-    if (!hash) return false;
-    const params = new URLSearchParams(hash);
-    return DOKIELI_HASH_PARAMS.some(p => params.has(p));
-  };
-
-  const isShowerSlideHash = (url) => {
-    if (typeof url !== 'string') return false;
-    const hashIdx = url.indexOf('#');
-    if (hashIdx < 0) return false;
-    const hash = url.slice(hashIdx + 1);
-    if (!hash) return false;
-    return !!document.getElementById(hash)?.classList?.contains('slide');
-  };
-
-  history.replaceState = function (state, title, url) {
-    if (hasDokieliHashParam() && isShowerSlideHash(url)) return;
-    return origReplace(state, title, url);
-  };
-  history.pushState = function (state, title, url) {
-    if (hasDokieliHashParam() && isShowerSlideHash(url)) return;
-    return origPush(state, title, url);
-  };
-
-  return () => {
-    history.replaceState = origReplace;
-    history.pushState = origPush;
-  };
-}
-
-// shower has no destroy() API; record listeners so teardownShower() can remove them.
-function startTrackedShower() {
-  showerExternalListeners = [];
-  showerHistoryRestore = patchHistoryForShower();
-  const targets = [document, document.body, window];
-  const originals = new Map();
-  for (const t of targets) {
-    originals.set(t, t.addEventListener);
-    t.addEventListener = function (type, listener, options) {
-      // prevent shower's keydown listener from hijacking p/l/backspace from PM (a bit hacky)
-      let tracked = listener;
-      if (type === 'keydown' && typeof listener === 'function') {
-        tracked = function (event) {
-          if (event.target?.closest?.('[contenteditable=""], [contenteditable="true"]')) return;
-          return listener.call(this, event);
-        };
-      }
-      showerExternalListeners.push({ target: t, type, listener: tracked, options });
-      return originals.get(t).call(t, type, tracked, options);
-    };
-  }
-  try {
-    const shwr = new shower();
-    shwr.start();
-    document.querySelectorAll('body > section.region[role="region"]').forEach(n => n.classList.add('do'));
-    return shwr;
-  } finally {
-    for (const t of targets) {
-      delete t.addEventListener;
-    }
-  }
-}
-
-function teardownShower() {
-  if (!showerInstance) return;
-  // Neutralizes dispatchEvent paths still reachable via stale per-slide click handlers.
-  showerInstance._isStarted = false;
-  for (const { target, type, listener, options } of showerExternalListeners) {
-    target.removeEventListener(type, listener, options);
-  }
-  showerExternalListeners = [];
-  document.querySelectorAll('body > section.region[role="region"]').forEach(n => n.remove());
-  showerInstance = null;
-  if (showerHistoryRestore) {
-    showerHistoryRestore();
-    showerHistoryRestore = null;
-  }
-}
-
 export function initSlideshow(options) {
   options = options || {};
-  options.progress = options.progress || true;
+  options.progress = options.progress !== false;
 
   //TODO: .shower can be anywhere?
   //TODO: check for rdf:type bibo:Slideshow or schema:PresentationDigitalDocument
-  if (getDocumentContentNode(document).classList.contains('shower')) {
-    //TODO: Check if .shower.list or .shower.full. pick a default in a dokieli or leave default to shower (list)?
+  if (!getDocumentContentNode(document).classList.contains('shower')) return;
 
-    //TODO: Check if .bibo:Slide, and if there is no .slide, add .slide
+  //TODO: Check if .bibo:Slide, and if there is no .slide, add .slide
 
-    if (!getDocumentContentNode(document).querySelector('.progress') && options.progress) {
-      getDocumentContentNode(document).appendChild(fragmentFromString('<div class="do progress"></div>'));
-    }
-
-    teardownShower();
-    showerInstance = startTrackedShower();
-    initSlideshowInteraction(showerInstance);
-  }
+  Slideshow.stop();
+  Slideshow.start();
+  initSlideshowInteraction(Slideshow);
 }
-
-// Shower's body keydown listener hijacks p/l/backspace from PM; tear down in author mode.
-window.addEventListener('dokieli:editor-mode-changed', (e) => {
-  if (!document.body.classList.contains('shower')) return;
-  if (e.detail?.mode === 'author') {
-    teardownShower();
-  } else if (e.detail?.mode === 'social') {
-    initSlideshow();
-  }
-});
 
 //TODO: Review grapoi
 function processPotentialAction(resourceInfo) {

--- a/src/slideshow.js
+++ b/src/slideshow.js
@@ -14,6 +14,7 @@ const MODES = { LIST: 'list', FULL: 'full' };
 
 let activeIndex = 0;
 let started = false;
+let keyupHandler = null;
 let keydownHandler = null;
 let hashHandler = null;
 
@@ -76,16 +77,22 @@ export function exitFullMode() {
   document.body.classList.add(MODES.LIST);
 }
 
+function onKeyup(e) {
+  if (!document.body.classList.contains('shower')) return;
+  if (inEditableTarget(e.target)) return;
+
+  if (isFull() && e.key === 'Escape') {
+    e.preventDefault();
+    exitFullMode();
+  }
+}
+
 function onKeydown(e) {
   if (!document.body.classList.contains('shower')) return;
   if (inEditableTarget(e.target)) return;
 
   if (isFull()) {
     switch (e.key) {
-      case 'Escape':
-        e.preventDefault();
-        exitFullMode();
-        return;
       case 'ArrowRight':
       case 'ArrowDown':
       case 'PageDown':
@@ -144,8 +151,10 @@ export function start() {
   syncFromHash();
 
   keydownHandler = onKeydown;
+  keyupHandler = onKeyup;
   hashHandler = syncFromHash;
   document.addEventListener('keydown', keydownHandler);
+  document.addEventListener('keyup', keyupHandler);
   window.addEventListener('hashchange', hashHandler);
 }
 
@@ -153,8 +162,9 @@ export function stop() {
   if (!started) return;
   started = false;
   if (keydownHandler) document.removeEventListener('keydown', keydownHandler);
+  if (keyupHandler) document.removeEventListener('keyup', keyupHandler);
   if (hashHandler) window.removeEventListener('hashchange', hashHandler);
-  keydownHandler = hashHandler = null;
+  keydownHandler = keyupHandler = hashHandler = null;
 }
 
 export function isStarted() {

--- a/src/slideshow.js
+++ b/src/slideshow.js
@@ -1,0 +1,173 @@
+/*!
+Copyright 2026 Virginia Balseiro <https://virginiabalseiro.com/>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+import { getDocumentContentNode } from './utils/html.js';
+
+const MODES = { LIST: 'list', FULL: 'full' };
+
+let activeIndex = 0;
+let started = false;
+let keydownHandler = null;
+let hashHandler = null;
+
+function getSlides() {
+  return Array.from(document.querySelectorAll('.shower .slide'));
+}
+
+function getProgress() {
+  return document.querySelector('.shower .progress');
+}
+
+function isList() {
+  return document.body.classList.contains(MODES.LIST);
+}
+
+function isFull() {
+  return document.body.classList.contains(MODES.FULL);
+}
+
+function inEditableTarget(target) {
+  return !!(target && target.closest && target.closest('[contenteditable=""], [contenteditable="true"]'));
+}
+
+function setActive(idx) {
+  const slides = getSlides();
+  if (!slides.length) return;
+  activeIndex = Math.max(0, Math.min(idx, slides.length - 1));
+  slides.forEach((s, i) => s.classList.toggle('active', i === activeIndex));
+  updateProgress();
+}
+
+function updateProgress() {
+  const progress = getProgress();
+  const slides = getSlides();
+  if (!progress || !slides.length) return;
+  const pct = ((activeIndex + 1) / slides.length) * 100;
+  progress.style.width = pct + '%';
+}
+
+export function goTo(idx) {
+  setActive(idx);
+}
+
+export function next() {
+  setActive(activeIndex + 1);
+}
+
+export function prev() {
+  setActive(activeIndex - 1);
+}
+
+export function enterFullMode() {
+  document.body.classList.remove(MODES.LIST);
+  document.body.classList.add(MODES.FULL);
+  setActive(activeIndex);
+}
+
+export function exitFullMode() {
+  document.body.classList.remove(MODES.FULL);
+  document.body.classList.add(MODES.LIST);
+}
+
+function onKeydown(e) {
+  if (!document.body.classList.contains('shower')) return;
+  if (inEditableTarget(e.target)) return;
+
+  if (isFull()) {
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        exitFullMode();
+        return;
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case 'PageDown':
+      case ' ':
+        e.preventDefault();
+        next();
+        return;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+      case 'PageUp':
+        e.preventDefault();
+        prev();
+        return;
+      case 'Home':
+        e.preventDefault();
+        setActive(0);
+        return;
+      case 'End':
+        e.preventDefault();
+        setActive(getSlides().length - 1);
+        return;
+    }
+  }
+}
+
+function syncFromHash() {
+  const hash = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : '';
+  if (!hash) return;
+  const slide = document.getElementById(hash);
+  if (!slide || !slide.classList.contains('slide')) return;
+  const idx = getSlides().indexOf(slide);
+  if (idx >= 0) setActive(idx);
+}
+
+export function start() {
+  if (started) return;
+  started = true;
+
+  const content = getDocumentContentNode(document);
+  if (!content || !content.classList.contains('shower')) {
+    started = false;
+    return;
+  }
+
+  if (!getProgress()) {
+    const div = document.createElement('div');
+    div.className = 'do progress';
+    content.appendChild(div);
+  }
+
+  if (!document.body.classList.contains(MODES.LIST) && !document.body.classList.contains(MODES.FULL)) {
+    document.body.classList.add(MODES.LIST);
+  }
+
+  setActive(0);
+  syncFromHash();
+
+  keydownHandler = onKeydown;
+  hashHandler = syncFromHash;
+  document.addEventListener('keydown', keydownHandler);
+  window.addEventListener('hashchange', hashHandler);
+}
+
+export function stop() {
+  if (!started) return;
+  started = false;
+  if (keydownHandler) document.removeEventListener('keydown', keydownHandler);
+  if (hashHandler) window.removeEventListener('hashchange', hashHandler);
+  keydownHandler = hashHandler = null;
+}
+
+export function isStarted() {
+  return started;
+}
+
+export default {
+  start,
+  stop,
+  goTo,
+  next,
+  prev,
+  enterFullMode,
+  exitFullMode,
+  isStarted,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,13 +1009,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shower/core@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@shower/core@npm:3.3.0"
-  checksum: 10c0/2f798fbef73039a4ce8fb764caeda8ec391d9961949cf99d8ae13b950e09f80f4c6f5e2661c132188c31a4456f281f1407ebb6b832fcf6db2d9260076be07881
-  languageName: node
-  linkType: hard
-
 "@sinclair/typebox@npm:^0.34.0":
   version: 0.34.49
   resolution: "@sinclair/typebox@npm:0.34.49"
@@ -2169,7 +2162,6 @@ __metadata:
   dependencies:
     "@axe-core/playwright": "npm:^4.9.1"
     "@playwright/test": "npm:^1.44.1"
-    "@shower/core": "npm:3.3.0"
     "@uvdsl/solid-oidc-client-browser": "npm:^0.2.2"
     "@vitest/coverage-istanbul": "npm:^4.0.18"
     "@vitest/coverage-v8": "npm:^4.0.18"


### PR DESCRIPTION
This PR removes dependency on shower for slides. Functionality is unchanged - PR with separate improvements coming up.

For now the `shower` class is kept in the CSS for backwards compatibility in legacy slideshows, but we could introduce a new class for new slideshows.