### PR TITLE
added data-client-id workflow for external dokieli.js use - SoSy27 

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -33,15 +33,51 @@ import { updateCollabUserIdentity } from './editor/editor.js';
 
 const ns = Config.ns;
 
-Config.OIDC['client_id'] = isLocalhost(window.location) ? process.env.DEV_CLIENT_ID : process.env.CLIENT_ID;
+// Read an embedder-supplied Client ID Document URL from the script tag, e.g.
+//   <script src="https://dokie.li/scripts/dokieli.js"
+//           data-client-id="https://example.org/clientid.json"></script>
+// This lets pages embedding dokieli cross-origin declare their own clientid
+// document, since they cannot rely on the build-time process.env.CLIENT_ID.
+function readScriptClientId() {
+  const s = document.currentScript;
+  if (!s || !s.dataset || !s.dataset.clientId) return null;
+  const value = s.dataset.clientId.trim();
+  if (!/^https:\/\//i.test(value)) {
+    console.warn('dokieli: ignoring data-client-id, must be an absolute https:// URL:', value);
+    return null;
+  }
+  return value;
+}
 
-const clientid = (Config.OIDC['client_id']) ? Config.OIDC['client_id'] : null;
+const scriptClientId = readScriptClientId();
+const builtinClientId = isLocalhost(window.location) ? process.env.DEV_CLIENT_ID : process.env.CLIENT_ID;
+
+// Embedder override wins; otherwise fall back to the build-time default.
+Config.OIDC['client_id'] = scriptClientId || builtinClientId || null;
+
+// Record whether the embedder opted in via data-client-id, so the login
+// functions below can adjust redirect_uri behavior for that path without
+// affecting deployments using the build-time CLIENT_ID convention.
+Config.OIDC['scriptClientId'] = scriptClientId;
+
+const clientid = Config.OIDC['client_id'];
 
 const currentScriptSameOrigin = isCurrentScriptSameOrigin();
 
-//Use static client registration if there is a Client ID Document URL and the dokieli script is on same origin as webpage and not Web Extension mode. Otherwise, use dynamic registration.
-// Manually configuring the database so that we can restore the session without using the refresher worker 
-Config['Session'] = (clientid && !Config['WebExtensionEnabled'] && currentScriptSameOrigin) ? new SessionCore({ client_id: clientid }, { database: new SessionIDB() }) : new SessionCore({ redirect_uris: [window.location.href], client_name: "dokieli" }, { database: new SessionIDB() });
+// Use static client registration when:
+//   - we have a Client ID Document URL, AND
+//   - we're not in a Web Extension context, AND
+//   - either the script is same-origin with the page (the build-time CLIENT_ID is
+//     trusted because the page author served the script themselves), OR the page
+//     author explicitly opted in via the data-client-id attribute on the <script>
+//     tag (the attribute is part of the embedding HTML, controlled by the page
+//     origin; a cross-origin script cannot set the attribute on its own tag).
+// Otherwise, fall back to dynamic registration.
+// Manually configuring the database so that we can restore the session without using the refresher worker
+const useStaticClientId = clientid && !Config['WebExtensionEnabled'] && (currentScriptSameOrigin || scriptClientId);
+Config['Session'] = useStaticClientId
+  ? new SessionCore({ client_id: clientid }, { database: new SessionIDB() })
+  : new SessionCore({ redirect_uris: [window.location.href], client_name: "dokieli" }, { database: new SessionIDB() });
 
 export async function restoreSession() {
   await Config['Session']?.handleRedirectFromLogin();
@@ -454,8 +490,20 @@ async function loginWithIDP(idpUrl) {
   Config.OIDC['authStartLocation'] = Config.OIDC['client_id'] ? window.location.href.split('#')[0] : null;
   updateBrowserStorageOIDC();
 
-  let redirect_uri = process.env.OIDC_REDIRECT_URI || (window.location.origin + '/');
-  redirect_uri = Config.OIDC['client_id'] ? redirect_uri : window.location.href.split('#')[0];
+  // For embedders who opted in via data-client-id, redirect back to the page
+  // that loaded dokieli. They control their own clientid document, so they can
+  // enumerate the pages they want to support there. Other paths keep the
+  // existing origin-root convention so existing deployments are unchanged.
+  let redirect_uri;
+  if (process.env.OIDC_REDIRECT_URI) {
+    redirect_uri = process.env.OIDC_REDIRECT_URI;
+  } else if (Config.OIDC['scriptClientId']) {
+    redirect_uri = window.location.href.split('#')[0];
+  } else if (Config.OIDC['client_id']) {
+    redirect_uri = window.location.origin + '/';
+  } else {
+    redirect_uri = window.location.href.split('#')[0];
+  }
 
   Config['Session']?.login(idpUrl, redirect_uri)
     .catch(e => {
@@ -475,8 +523,17 @@ async function loginWithIDP(idpUrl) {
   Config.OIDC['authStartLocation'] = window.location.href.split('#')[0];
   updateBrowserStorageOIDC();
 
-  let redirect_uri = process.env.OIDC_REDIRECT_URI || (window.location.origin + '/');
-  redirect_uri = Config.OIDC['client_id'] ? redirect_uri :  window.location.href.split('#')[0];
+  // See loginWithIDP above: data-client-id embedders get page-scoped redirects.
+  let redirect_uri;
+  if (process.env.OIDC_REDIRECT_URI) {
+    redirect_uri = process.env.OIDC_REDIRECT_URI;
+  } else if (Config.OIDC['scriptClientId']) {
+    redirect_uri = window.location.href.split('#')[0];
+  } else if (Config.OIDC['client_id']) {
+    redirect_uri = window.location.origin + '/';
+  } else {
+    redirect_uri = window.location.href.split('#')[0];
+  }
 
   // Redirects away from dokieli :( but hopefully only briefly :)
   Config['Session']?.login(idp, redirect_uri)


### PR DESCRIPTION
## What

Lets cross-origin embedders opt into static client registration by declaring a Client ID Document URL via a `data-client-id` attribute on the dokieli script tag, and (when that attribute is present) redirects post-login back to the embedding page rather than the origin root.

## Why

For embedders who want their dokieli integration to always pick up the latest fixes and features without re-uploading bundles, loading dokieli assets directly from `https://dokie.li/scripts/dokieli.js` is the obvious pattern, and it's one the README explicitly invites. In practice, login fails the moment that script is loaded from any non-`dokie.li` origin, for two compounding reasons:

**1. The static-registration gate excludes cross-origin embedders.**
[`src/auth.js:44`](src/auth.js#L44) requires `isCurrentScriptSameOrigin()` to be true before honoring a Client ID Document URL. When the page is on (say) `https://my-pod.example` and the script is loaded from `https://dokie.li`, that check returns false, the ternary falls through to dynamic client registration, and any Client ID Document the embedder may have published is never consulted.

**2. In the dynamic-registration branch, the `redirect_uri` sent at login time doesn't match the one registered.**
At registration ([`src/auth.js:44`](src/auth.js#L44)) the OIDC client is constructed with `redirect_uris: [window.location.href]`, the full page URL. At login ([`src/auth.js:457-458`](src/auth.js#L457-L458) and the matching block in `signInWithOIDC`) the redirect is recomputed:

```js
let redirect_uri = process.env.OIDC_REDIRECT_URI || (window.location.origin + '/');
redirect_uri = Config.OIDC['client_id'] ? redirect_uri : window.location.href.split('#')[0];
```

`Config.OIDC['client_id']` is still truthy here. It was assigned from the build-time process.env.CLIENT_ID on line 36, even though that value isn't being used for registration in this branch. The ternary therefore picks `window.location.origin + '/'` (the origin root) instead of the full page URL. The IdP looks up the dynamic client by its opaque `client_id`, finds a registration whose `redirect_uris` is `[<full page URL>]`, sees the request asking to redirect to `<origin>/`, and rejects with `invalid_redirect_uri`. End-user-visible result: login is silently broken for any cross-origin embed.

## Behavior matrix

| Setup | Before | After |
|---|---|---|
| dokie.li own pages (build `CLIENT_ID`, no attribute) | static, redirect to `origin + '/'` | unchanged |
| Self-hosted with build `CLIENT_ID`, no attribute | static, redirect to `origin + '/'` | unchanged |
| Build with `OIDC_REDIRECT_URI` set | static, redirect to env value | unchanged |
| Cross-origin, no attribute | dynamic registration | unchanged |
| **NEW**: any embed with `data-client-id` | not previously possible | static with attribute value, redirect to `window.location.href` |

## Why the `data-client-id` value is trustworthy enough to skip `currentScriptSameOrigin`

`data-client-id` is read from `document.currentScript.dataset.clientId`, i.e. from the embedding HTML, not from the script's bytes. A cross-origin script cannot set the attribute on its own tag; only the page author can. So the value is exactly as trustworthy as any other attribute the page author wrote in their own HTML, which is the existing trust boundary for the page. The original `currentScriptSameOrigin` check is preserved for the build-time `process.env.CLIENT_ID` path.

## Why the page-scoped `redirect_uri` is gated on `data-client-id`

The `origin + '/'` redirect convention works when one landing page covers a whole site (which is true for dokie.li and for most self-hosted single-tenant deployments). It breaks for multi-tenant CSS pods where the embedder owns a subpath, not the origin. Scoping the new `redirect_uri = window.location.href` behavior to the `data-client-id` opt-in means existing deployments are byte-for-byte unchanged; only embedders who have explicitly declared their own clientid document (and therefore can enumerate the pages they want to support there) get the new behavior.

## Verification

Tested on our University of St. Gallen server (`https://wiser-solid-xi.interactions.ics.unisg.ch/sosy27-dokieli/public/test-direct.html`), which is hosting the dokieli.js file created from this branch.

## Tests

Lint and existing test suite pass locally. If the idea suits, then I would be happy to add the tests as well if you want.

## Open question for review

Currently the new `redirect_uri = window.location.href` behavior is unconditional whenever `data-client-id` is set. If an embedder would prefer to keep the origin-root convention even with a custom clientid document, would you want a second attribute (e.g. `data-redirect-uri="origin"` / `"page"`) to choose? 
