### PR TITLE
Chore/collab editing test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint": "^10.0.3",
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-license-header": "^0.8.0",
+    "fake-indexeddb": "^6.0.0",
     "husky": "^9.0.11",
     "jest-environment-jsdom": "^30.2.0",
     "patch-package": "^8.0.0",

--- a/tests/e2e/browser/collab.spec.js
+++ b/tests/e2e/browser/collab.spec.js
@@ -23,17 +23,28 @@ const localScriptContent = fs.readFileSync(path.resolve("./scripts/dokieli.js"),
 const augmentedScript = localScriptContent.replace(
   "window.DO = DO;",
   `window.DO = DO;
-window.__doCollabTest = { showReviewPanel: showResourceReviewChanges };`
+window.doCollabTest = {
+  showReviewPanel: showResourceReviewChanges,
+  addYjsVersion,
+  getYjsVersions,
+  restoreYjsContent,
+  showEditHistory,
+  getCurrentVersionKey,
+};`
 );
 
 async function setupRoutes(page, { augment = false } = {}) {
   await page.route("https://dokie.li/**", (route) => route.abort());
-  await page.route("https://dokie.li/scripts/dokieli.js", (route) =>
+  await page.route("**/scripts/dokieli.js", (route) =>
     route.fulfill({
       contentType: "application/javascript",
       body: augment ? augmentedScript : localScriptContent,
     })
   );
+}
+
+function versionPayload(content, updated) {
+  return { content, updated, mediaType: "text/html", actor: null };
 }
 
 async function enableAuthorMode(page) {
@@ -122,7 +133,7 @@ test.describe("review changes panel", () => {
 
   test("appears when local and remote content differ", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
@@ -132,21 +143,20 @@ test.describe("review changes panel", () => {
 
   test("contains a diff visualization with ins and del elements", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
     const diff = page.locator("#review-changes .do-diff");
     await expect(diff).toBeVisible();
 
-    // Both insertions and deletions should appear in the diff
     await expect(diff.locator("ins").first()).toBeVisible();
     await expect(diff.locator("del").first()).toBeVisible();
   });
 
   test("shows a statistics table with added and removed counts", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
@@ -163,7 +173,7 @@ test.describe("review changes panel", () => {
 
   test("provides save-local, save-remote, and submit action buttons", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
@@ -175,7 +185,7 @@ test.describe("review changes panel", () => {
 
   test("close button removes the panel and clears review state", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
@@ -189,7 +199,7 @@ test.describe("review changes panel", () => {
 
   test("submit button merges changes and removes the panel", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
@@ -201,7 +211,7 @@ test.describe("review changes panel", () => {
 
   test("save-local button dismisses the panel", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
@@ -213,7 +223,7 @@ test.describe("review changes panel", () => {
 
   test("save-remote button dismisses the panel", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
@@ -231,7 +241,7 @@ test.describe("review changes panel", () => {
 
     await page.evaluate(
       ([older, current, opts]) =>
-        window.__doCollabTest.showReviewPanel(older, current, null, opts),
+        window.doCollabTest.showReviewPanel(older, current, null, opts),
       [versionContent, currentContent, { mode: "edit-history-preview" }]
     );
 
@@ -249,7 +259,7 @@ test.describe("review changes panel", () => {
       "<html><body><article><p>Identical content on both sides.</p></article></body></html>";
 
     await page.evaluate(
-      ([content]) => window.__doCollabTest.showReviewPanel(content, content, null, {}),
+      ([content]) => window.doCollabTest.showReviewPanel(content, content, null, {}),
       [sameContent]
     );
 
@@ -258,7 +268,7 @@ test.describe("review changes panel", () => {
 
   test("review panel has a label and accessible structure", async ({ page }) => {
     await page.evaluate(
-      ([local, remote]) => window.__doCollabTest.showReviewPanel(local, remote, null, {}),
+      ([local, remote]) => window.doCollabTest.showReviewPanel(local, remote, null, {}),
       [LOCAL_HTML, REMOTE_HTML]
     );
 
@@ -296,6 +306,7 @@ test.describe("collab save event", () => {
 async function openDemoPage(browser) {
   const context = await browser.newContext();
   const page = await context.newPage();
+  await setupRoutes(page, { augment: true });
   await page.goto("/demo");
   await page.waitForLoadState("domcontentloaded");
 
@@ -313,8 +324,11 @@ async function openDemoPage(browser) {
   return { context, page };
 }
 
-test.describe("multi-user collab via WebSocket", () => {
-  test.describe.configure({ timeout: 60000 });
+// Serial so each test gets a clean /demo y-websocket room.
+test.describe("demo-backed collab", () => {
+  test.describe.configure({ mode: "serial", timeout: 60000 });
+
+  test.describe("multi-user collab via WebSocket", () => {
 
   test("changes typed by one user appear in a second user's editor", async ({ browser }) => {
     const { context: ctx1, page: page1 } = await openDemoPage(browser);
@@ -389,5 +403,159 @@ test.describe("multi-user collab via WebSocket", () => {
     expect(fired).toBe(true);
 
     await context.close();
+  });
+  });
+
+  test.describe("edit-history panel", () => {
+    test("a version added via addYjsVersion appears in the list", async ({ browser }) => {
+      const { context, page } = await openDemoPage(browser);
+      const datetime = "2099-05-22T10:00:00Z";
+
+      await page.evaluate((v) => window.doCollabTest.addYjsVersion(v), versionPayload(
+        "<html><body><article><p>v1</p></article></body></html>",
+        datetime
+      ));
+
+      await page.evaluate(() => window.doCollabTest.showEditHistory());
+
+      await expect(page.locator(
+        `#document-edit-history ul.versions li[data-datetime="${datetime}"]`
+      )).toBeVisible();
+      await context.close();
+    });
+
+    // Future timestamps so my versions sort newer than any wall-clock autosave.
+    test("versions render newest first", async ({ browser }) => {
+      const { context, page } = await openDemoPage(browser);
+      const added = [
+        "2099-01-01T00:00:00Z",
+        "2099-03-01T00:00:00Z",
+        "2099-05-01T00:00:00Z",
+      ];
+
+      await page.evaluate((dates) => {
+        const add = window.doCollabTest.addYjsVersion;
+        for (const updated of dates) {
+          add({ content: `<p>${updated}</p>`, updated, mediaType: "text/html" });
+        }
+      }, added);
+
+      await page.evaluate(() => window.doCollabTest.showEditHistory());
+
+      const datetimes = await page
+        .locator("#document-edit-history ul.versions li")
+        .evaluateAll((els) => els.map((el) => el.getAttribute("data-datetime")));
+      expect(datetimes.slice(0, 3)).toEqual([
+        "2099-05-01T00:00:00Z",
+        "2099-03-01T00:00:00Z",
+        "2099-01-01T00:00:00Z",
+      ]);
+      await context.close();
+    });
+  });
+
+  test.describe("version restore workflow", () => {
+    test("preview then restore replaces editor content", async ({ browser }) => {
+      const { context, page } = await openDemoPage(browser);
+      const restoredHTML =
+        "<html><body><article><p>this is the restored content</p></article></body></html>";
+
+      await page.evaluate((v) => window.doCollabTest.addYjsVersion(v), versionPayload(
+        restoredHTML,
+        "2026-05-22T10:00:00Z"
+      ));
+
+      const editor = page.locator(".ProseMirror");
+      await editor.click();
+      await page.keyboard.press("Control+a");
+      await page.keyboard.press("Backspace");
+      await page.keyboard.type("scratch text that should be replaced");
+
+      await page.evaluate(() => window.doCollabTest.showEditHistory());
+      await page.locator("#document-edit-history button.edit-history-preview").first().click();
+
+      await expect(page.locator("#review-changes")).toBeVisible();
+      await page.locator("#review-changes .version-restore").click();
+
+      await expect(editor).toContainText("this is the restored content");
+      await expect(editor).not.toContainText("scratch text");
+      await context.close();
+    });
+
+    test("restoring a version disables its preview button", async ({ browser }) => {
+      const { context, page } = await openDemoPage(browser);
+      const olderKey = "2099-05-22T10:00:00Z";
+      const newerKey = "2099-05-22T12:00:00Z";
+
+      await page.evaluate((v) => window.doCollabTest.addYjsVersion(v), versionPayload(
+        "<html><body><article><p>older</p></article></body></html>", olderKey));
+      await page.evaluate((v) => window.doCollabTest.addYjsVersion(v), versionPayload(
+        "<html><body><article><p>newer</p></article></body></html>", newerKey));
+
+      await page.evaluate(() => window.doCollabTest.showEditHistory());
+
+      const olderPreview = page.locator(
+        `#document-edit-history button.edit-history-preview[data-key="${olderKey}"]`
+      );
+      await expect(olderPreview).toBeEnabled();
+
+      await olderPreview.click();
+      await page.locator("#review-changes .version-restore").click();
+
+      await expect(olderPreview).toBeDisabled();
+      await context.close();
+    });
+  });
+
+  test.describe("version cap", () => {
+    test("keeps only the newest 20 versions and renders them in the panel", async ({ browser }) => {
+      const { context, page } = await openDemoPage(browser);
+      await page.evaluate(() => {
+        const add = window.doCollabTest.addYjsVersion;
+        for (let i = 0; i < 25; i++) {
+          const stamp = `2026-01-01T00:00:${String(i).padStart(2, "0")}Z`;
+          add({ content: `<p>${i}</p>`, updated: stamp, mediaType: "text/html" });
+        }
+      });
+
+      const stored = await page.evaluate(() => window.doCollabTest.getYjsVersions().length);
+      expect(stored).toBe(20);
+
+      await page.evaluate(() => window.doCollabTest.showEditHistory());
+      const items = page.locator("#document-edit-history ul.versions li");
+      await expect(items).toHaveCount(20);
+      await context.close();
+    });
+  });
+
+  test.describe("multi-user version propagation", () => {
+    test("a version saved by user 1 appears in user 2's edit-history panel", async ({ browser }) => {
+      const { context: ctx1, page: page1 } = await openDemoPage(browser);
+      const { context: ctx2, page: page2 } = await openDemoPage(browser);
+      const datetime = "2099-05-22T13:00:00Z";
+
+      await page1.evaluate((v) => window.doCollabTest.addYjsVersion(v), versionPayload(
+        "<html><body><article><p>from user 1</p></article></body></html>",
+        datetime
+      ));
+
+      await expect
+        .poll(
+          () => page2.evaluate(
+            (d) => window.doCollabTest.getYjsVersions().some(v => v.updated === d),
+            datetime
+          ),
+          { timeout: 5000 }
+        )
+        .toBe(true);
+
+      await page2.evaluate(() => window.doCollabTest.showEditHistory());
+      await expect(page2.locator(
+        `#document-edit-history ul.versions li[data-datetime="${datetime}"]`
+      )).toBeVisible();
+
+      await ctx1.close();
+      await ctx2.close();
+    });
   });
 });

--- a/tests/unit/editor/yjs-collab.test.js
+++ b/tests/unit/editor/yjs-collab.test.js
@@ -1,0 +1,221 @@
+/*!
+Copyright 2012-2026 Sarven Capadisli <https://csarven.ca/>
+Copyright 2023-2026 Virginia Balseiro <https://virginiabalseiro.com/>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as Y from 'yjs';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import { IDBFactory } from 'fake-indexeddb';
+import { prosemirrorToYDoc } from 'y-prosemirror';
+import { DOMParser as PMDOMParser } from 'prosemirror-model';
+import { schema } from 'src/editor/schema/base.js';
+import { getYjsVersionsFromIDB } from 'src/editor/editor.js';
+
+// Mirror updates between two Y.Docs, simulating a network connection. Can be disconnected to simulate offline edits, then reconnected to sync up.
+function pipe(a, b) {
+  let connected = true;
+  const onA = (update, origin) => { if (connected && origin !== b) Y.applyUpdate(b, update, a); };
+  const onB = (update, origin) => { if (connected && origin !== a) Y.applyUpdate(a, update, b); };
+  a.on('update', onA);
+  b.on('update', onB);
+  return {
+    disconnect() { connected = false; },
+    reconnect() {
+      connected = true;
+      Y.applyUpdate(b, Y.encodeStateAsUpdate(a, Y.encodeStateVector(b)), a);
+      Y.applyUpdate(a, Y.encodeStateAsUpdate(b, Y.encodeStateVector(a)), b);
+    },
+    destroy() { a.off('update', onA); b.off('update', onB); },
+  };
+}
+
+// Wipe IDB so room state doesn't leak between tests.
+function resetIDB() {
+  globalThis.indexedDB = new IDBFactory();
+}
+
+describe('Yjs two-doc convergence (no network)', () => {
+  let docA, docB, link;
+
+  beforeEach(() => {
+    docA = new Y.Doc();
+    docB = new Y.Doc();
+    link = pipe(docA, docB);
+  });
+
+  afterEach(() => {
+    link.destroy();
+    docA.destroy();
+    docB.destroy();
+  });
+
+  test('edits on doc A propagate to doc B', () => {
+    const textA = docA.getText('t');
+    textA.insert(0, 'hello');
+    expect(docB.getText('t').toString()).toBe('hello');
+  });
+
+  test('concurrent edits while offline converge after reconnect', () => {
+    const textA = docA.getText('t');
+    textA.insert(0, 'shared');
+    expect(docB.getText('t').toString()).toBe('shared');
+
+    link.disconnect();
+    docA.getText('t').insert(6, ' from A');
+    docB.getText('t').insert(6, ' from B');
+    expect(docA.getText('t').toString()).not.toBe(docB.getText('t').toString());
+
+    link.reconnect();
+    expect(docA.getText('t').toString()).toBe(docB.getText('t').toString());
+  });
+
+  test('late joiner receives full state on reconnect', () => {
+    docA.getText('t').insert(0, 'preexisting');
+    link.disconnect();
+
+    const docC = new Y.Doc();
+    const c = pipe(docA, docC);
+    Y.applyUpdate(docC, Y.encodeStateAsUpdate(docA));
+    expect(docC.getText('t').toString()).toBe('preexisting');
+
+    c.destroy();
+    docC.destroy();
+  });
+});
+
+describe('y-prosemirror seeds Y.XmlFragment from a ProseMirror doc', () => {
+  test('prosemirrorToYDoc produces an XmlFragment that mirrors the source', () => {
+    const html = '<p>hello <strong>world</strong></p>';
+    const tmpl = document.implementation.createHTMLDocument('');
+    tmpl.body.innerHTML = html;
+    const pmDoc = PMDOMParser.fromSchema(schema).parse(tmpl.body);
+
+    const seeded = prosemirrorToYDoc(pmDoc);
+    const frag = seeded.getXmlFragment('prosemirror');
+    expect(frag.length).toBeGreaterThan(0);
+
+    const fresh = new Y.Doc();
+    Y.applyUpdate(fresh, Y.encodeStateAsUpdate(seeded));
+    expect(fresh.getXmlFragment('prosemirror').toString())
+      .toBe(frag.toString());
+  });
+});
+
+// Mirrors addYjsVersion
+describe('Versions Y.Map semantics', () => {
+  const VERSIONS_MAP = 'versions';
+  const MAX = 20;
+
+  function addVersion(ydoc, key, payload) {
+    const map = ydoc.getMap(VERSIONS_MAP);
+    ydoc.transact(() => {
+      map.set(key, payload);
+      ydoc.getMap('meta').set('currentVersionKey', key);
+      if (map.size > MAX) {
+        const sorted = Array.from(map.keys()).sort();
+        for (let i = 0; i < map.size - MAX; i++) map.delete(sorted[i]);
+      }
+    });
+  }
+
+  function readVersions(ydoc) {
+    return Array.from(ydoc.getMap(VERSIONS_MAP).entries())
+      .sort((a, b) => b[0].localeCompare(a[0]))
+      .map(([, v]) => v);
+  }
+
+  test('versions are returned newest first', () => {
+    const ydoc = new Y.Doc();
+    addVersion(ydoc, '2026-01-01T00:00:00Z', { label: 'oldest' });
+    addVersion(ydoc, '2026-03-01T00:00:00Z', { label: 'middle' });
+    addVersion(ydoc, '2026-05-01T00:00:00Z', { label: 'newest' });
+
+    const versions = readVersions(ydoc);
+    expect(versions.map(v => v.label)).toEqual(['newest', 'middle', 'oldest']);
+  });
+
+  test('drops oldest entries past MAX_VERSIONS (20)', () => {
+    const ydoc = new Y.Doc();
+    for (let i = 0; i < 25; i++) {
+      const key = `2026-01-01T00:00:${String(i).padStart(2, '0')}Z`;
+      addVersion(ydoc, key, { i });
+    }
+    const versions = readVersions(ydoc);
+    expect(versions).toHaveLength(MAX);
+    expect(versions[0].i).toBe(24);
+    expect(versions[versions.length - 1].i).toBe(5);
+  });
+
+  test('version updates propagate over the two-doc pipe', () => {
+    const a = new Y.Doc();
+    const b = new Y.Doc();
+    const link = pipe(a, b);
+
+    addVersion(a, '2026-05-22T10:00:00Z', { label: 'from A' });
+    expect(b.getMap('versions').get('2026-05-22T10:00:00Z')).toEqual({ label: 'from A' });
+
+    addVersion(b, '2026-05-22T11:00:00Z', { label: 'from B' });
+    expect(a.getMap('versions').get('2026-05-22T11:00:00Z')).toEqual({ label: 'from B' });
+
+    link.destroy();
+    a.destroy();
+    b.destroy();
+  });
+});
+
+describe('IndexeddbPersistence (fake-indexeddb)', () => {
+  beforeEach(() => { resetIDB(); });
+
+  test('state written by one doc is loaded by a fresh doc with the same room', async () => {
+    const room = 'test-room-' + Math.random().toString(36).slice(2);
+
+    const writer = new Y.Doc();
+    const writerIDB = new IndexeddbPersistence(room, writer);
+    await writerIDB.whenSynced;
+    writer.getText('t').insert(0, 'persisted');
+    await new Promise(r => setTimeout(r, 50)); // flush IDB write
+    await writerIDB.destroy();
+    writer.destroy();
+
+    const reader = new Y.Doc();
+    const readerIDB = new IndexeddbPersistence(room, reader);
+    await readerIDB.whenSynced;
+    expect(reader.getText('t').toString()).toBe('persisted');
+    await readerIDB.destroy();
+    reader.destroy();
+  });
+
+  test('getYjsVersionsFromIDB reads versions written by another doc on the same room', async () => {
+    // Room key derives from window.location (set by vitest.setup.js).
+    const room = encodeURIComponent('https://example.com/');
+
+    const writer = new Y.Doc();
+    const writerIDB = new IndexeddbPersistence(room, writer);
+    await writerIDB.whenSynced;
+
+    const versions = writer.getMap('versions');
+    writer.transact(() => {
+      versions.set('2026-05-22T09:00:00Z', { label: 'v1' });
+      versions.set('2026-05-22T10:00:00Z', { label: 'v2' });
+    });
+    await new Promise(r => setTimeout(r, 50));
+    await writerIDB.destroy();
+    writer.destroy();
+
+    const result = await getYjsVersionsFromIDB({});
+    expect(result.map(v => v.label)).toEqual(['v2', 'v1']);
+  });
+});

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,10 +1,17 @@
 import { JSDOM } from "jsdom";
 import { vi } from "vitest";
+import {
+  IDBCursor, IDBCursorWithValue, IDBDatabase, IDBFactory, IDBIndex,
+  IDBKeyRange, IDBObjectStore, IDBOpenDBRequest, IDBRequest,
+  IDBTransaction, IDBVersionChangeEvent,
+} from "fake-indexeddb";
 
 vi.mock("./src/i18n", async () => {
   const mod = await import("./tests/utils/mocki18n.js");
   return { i18n: mod.i18n };
 });
+
+vi.mock("leaflet-gpx", () => ({}));
 
 const htmlContent = `
 <!DOCTYPE html>
@@ -31,6 +38,17 @@ const dom = new JSDOM(htmlContent.trim(), { url: "https://example.com/" });
 
 global.window = dom.window;
 global.document = dom.window.document;
+
+const idbGlobals = {
+  indexedDB: new IDBFactory(),
+  IDBCursor, IDBCursorWithValue, IDBDatabase, IDBFactory, IDBIndex,
+  IDBKeyRange, IDBObjectStore, IDBOpenDBRequest, IDBRequest,
+  IDBTransaction, IDBVersionChangeEvent,
+};
+for (const [k, v] of Object.entries(idbGlobals)) {
+  globalThis[k] = v;
+  dom.window[k] = v;
+}
 
 // Polyfill helper
 function patchElementPrototype(win) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2131,6 +2131,7 @@ __metadata:
     eslint: "npm:^10.0.3"
     eslint-plugin-header: "npm:^3.1.1"
     eslint-plugin-license-header: "npm:^0.8.0"
+    fake-indexeddb: "npm:^6.0.0"
     fs: "npm:^0.0.1-security"
     http-link-header: "npm:^1.1.3"
     husky: "npm:^9.0.11"
@@ -2537,6 +2538,13 @@ __metadata:
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
   checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
+  languageName: node
+  linkType: hard
+
+"fake-indexeddb@npm:^6.0.0":
+  version: 6.2.5
+  resolution: "fake-indexeddb@npm:6.2.5"
+  checksum: 10c0/6c5e2fe84a61daa06d7ad63699d1041fe61847f15f92db12415634b3db94f363a64be9e08a3c3c4434af9c3c0132086b85c4d5dc5e8e06edae1e7daf70ce1f3c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR:
* add unit tests for Yjs collaborative editing 
* expand on the e2e browser test intialized in 808f812d1ef4a59b66cc75ceef97c369508512b2  
* some minor fixes to test setup, server, mocks, and config; add `fake-indexeddb` for mocks, etc.