### PR TITLE
Implement WAC Authorization conditions

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -25,7 +25,7 @@ import { accessModeAllowed, accessModePossiblyAllowed } from './access.js';
 import { domSanitize, sanitizeInsertAdjacentHTML, sanitizeIRI, sanitizeObject, htmlEncode, sanitizeIRIs } from './utils/sanitization.js';
 import { escapeRDFLiteral, generateAttributeId, generateUUID } from './util.js';
 import { setAcceptRDFTypes } from './fetcher.js';
-import { forceTrailingSlash, generateDataURI, getAbsoluteIRI, getBaseURL, isHttpOrHttpsProtocol, isFileProtocol, stripFragmentFromString, getFragmentFromString, getURLLastPath, currentLocation } from './uri.js';
+import { forceTrailingSlash, generateDataURI, getAbsoluteIRI, getBaseURL, isHttpOrHttpsProtocol, isFileProtocol, isUrl, stripFragmentFromString, getFragmentFromString, getURLLastPath, currentLocation } from './uri.js';
 import { getAccessSubjects, getACLResourceGraph, getAgentInbox, getAgentName, getAuthorizationsMatching, getGraphAuthors, getGraphContributors, getGraphEditors, getGraphImage, getGraphLabelOrIRI, getGraphPerformers, getGraphTypes, getLinkRelation, getLinkRelationFromHead, getResourceGraph, getUserContacts, getUserLabelOrIRI, serializeData, getSubjectInfo, getRDFSerializer } from './graph.js';
 import { notifyInbox, sendNotifications, showContactsActivities, initializeNotifications } from './activity.js';
 import Config from './config.js';
@@ -1189,6 +1189,7 @@ function updateAuthorization(accessContext, selectedMode, accessSubject, subject
   var deleteGraph = '';
   // var whereGraph = '';
   var authorizationSubject;
+  var authorizationCondition;
 
   var authorizationForAccessSubjectInserted = false;
 
@@ -1233,6 +1234,8 @@ function updateAuthorization(accessContext, selectedMode, accessSubject, subject
           });
         }
         else {
+          var accessConditions = authorizations[authorization].condition;
+
           //When only one particular agent uses this Authorization, remove the whole
           if (!multipleAccessSubjects) {
             deleteGraph += `
@@ -1242,6 +1245,26 @@ acl:${deleteAccessObjectProperty} <${documentURL}> ;
 acl:mode ${deleteAccessModes} ;
 acl:${deleteAccessSubjectProperty} <${deleteAccessSubject}> .
 `;
+            accessConditions.forEach(condition => {
+              if (typeof condition !== 'object') return;
+              const condParts = [];
+              Object.entries(condition).forEach(([predIRI, objects]) => {
+                if (predIRI === 'id') return;
+                const values = Array.isArray(objects) ? objects : [objects];
+                condParts.push(`<${predIRI}> <${values.join('>, <')}>`);
+              });
+              if (isUrl(condition.id)) {
+                deleteGraph += `\n<${authorization}> acl:condition <${condition.id}> .\n`;
+                deleteGraph += `<${condition.id}>\n${condParts.join(' ;\n')} .\n`;
+              }
+              /* XXX: Do not remove this comment
+              Blank node deleting via SPARQL Update or Solid Protocol N3 Patch (or another protocol) is not guaranteed to work. Worst case here is that there is dangling, e.g., <${authorization} acl:condition [ ... ] but it is not effective since it doesn't conform to https://solid.github.io/web-access-control-spec/#authorization-conformance . It'll never be matched with the exception of clients reusing the same Authorization IRI in the future to add the other parts of the Authorization rule. Even in this case access
+              Alternatively, TODO: modify the triple directly and use PUT instead
+              // else {
+              //   deleteGraph += `\n<${authorization}> acl:condition [ ${condParts.join(' ; ')} ] .\n`;
+              // }
+              */
+            });
           }
           //When we need to remove the access of only one of the access subjects from an Authorization (and leave the rest untouched)
           else {
@@ -1271,6 +1294,16 @@ acl:accessTo <${documentURL}> ;
 acl:mode <${updatedMode.join('>, <')}> ;
 acl:${subjectType} <${accessSubject}> .
 `;
+
+      if (Config.Resource[effectiveACLResource]?.conditions?.length) {
+        authorizationCondition = '#' + generateAttributeId();
+        insertGraph += `
+<${authorizationSubject}> acl:condition <${authorizationCondition}> .
+<${authorizationCondition}>
+a acl:ClientCondition ;
+acl:clientClass foaf:Agent .
+`;
+      }
 
       patches.push({ 'insert': insertGraph });
     }
@@ -1318,9 +1351,27 @@ acl:${subjectType} <${accessSubject}> .
       authorizationSubject = '#' + generateAttributeId();
 
       var additionalProperties = [];
-      ['agent', 'agentClass', 'agentGroup', 'origin'].forEach(key => {
+      var conditionInserts = '';
+      ['agent', 'agentClass', 'agentGroup', 'origin', 'condition'].forEach(key => {
         if (updatedAuthorizations[authorization][key] && updatedAuthorizations[authorization][key].length) {
-          additionalProperties.push(`acl:${key} <${updatedAuthorizations[authorization][key].join('>, <')}>`);
+          if (key === 'condition') {
+            if (Config.Resource[effectiveACLResource]?.conditions?.length) {
+              Object.values(updatedAuthorizations[authorization][key]).forEach((condition) => {
+                authorizationCondition = '#' + generateAttributeId();
+                additionalProperties.push(`acl:condition <${authorizationCondition}>`);
+                const condParts = [];
+                Object.entries(condition).forEach(([predIRI, objects]) => {
+                  if (predIRI === 'id') return;
+                  const values = Array.isArray(objects) ? objects : [objects];
+                  condParts.push(`<${predIRI}> <${values.join('>, <')}>`);
+                });
+                conditionInserts += `\n<${authorizationCondition}>\n${condParts.join(' ;\n')} .\n`;
+              });
+            }
+          }
+          else {
+            additionalProperties.push(`acl:${key} <${updatedAuthorizations[authorization][key].join('>, <')}>`);
+          }
         }
       })
       additionalProperties = additionalProperties.join(';\n');
@@ -1332,6 +1383,7 @@ acl:accessTo <${documentURL}> ;
 acl:mode <${updatedAuthorizations[authorization].mode.join('>, <')}> ;
 ${additionalProperties} .
 `;
+      insertGraph += conditionInserts;
     });
 
     //Here we add the new Authorization that needs to be added as per user's selection
@@ -1345,6 +1397,16 @@ acl:accessTo <${documentURL}> ;
 acl:mode <${updatedMode.join('>, <')}> ;
 acl:${subjectType} <${accessSubject}> .
 `;
+
+      if (Config.Resource[effectiveACLResource]?.conditions?.length) {
+        authorizationCondition = '#' + generateAttributeId();
+        insertGraph += `
+<${authorizationSubject}> acl:condition <${authorizationCondition}> .
+<${authorizationCondition}>
+a acl:ClientCondition ;
+acl:clientClass foaf:Agent .
+`;
+      }
     }
 
     patches.push({ 'insert': insertGraph });

--- a/src/graph.js
+++ b/src/graph.js
@@ -19,7 +19,7 @@ import rdf from "rdf-ext";
 import { RdfaParser } from "rdfa-streaming-parser";
 import { Readable } from "readable-stream";
 import Config from './config.js'
-import { stripFragmentFromString, getBaseURL, getPathURL, getAbsoluteIRI, getParentURLPath, currentLocation, getMediaTypeURIs } from './uri.js'
+import { stripFragmentFromString, getBaseURL, getPathURL, getAbsoluteIRI, getParentURLPath, currentLocation, getMediaTypeURIs, isUrl } from './uri.js'
 import { escapeRegExp, uniqueArray } from './util.js'
 import { domSanitize, safeObjectAssign, sanitizeInsertAdjacentHTML, sanitizeIRI, sanitizeIRIOrBNode, sanitizeIRIs, sanitizeObject } from './utils/sanitization.js'
 import { parseMarkdown } from "./utils/html.js";
@@ -1750,9 +1750,23 @@ export function getACLResourceGraph(documentURL, iri, options = {}) {
 
         return getResourceGraph(aclResource, {})
           .then(({ response, graph: g }) => {
+            const link = response.headers.get('Link');
+            const conditions = [];
+
+            //https://solid.github.io/web-access-control-spec/#client-link-condition
+            if (link) {
+              const linkHeaders = LinkHeader.parse(link);
+              if (linkHeaders.has('rel', 'http://www.w3.org/ns/auth/acl#condition')) {
+                linkHeaders.rel('http://www.w3.org/ns/auth/acl#condition').forEach(l => {
+                  conditions.push(l.uri);
+                });
+              }
+            }
+
             Config.Resource[documentURL]['acl']['effectiveACLResource'] = aclResource;
             Config.Resource[aclResource] = {};
             Config.Resource[aclResource]['response'] = response;
+            Config.Resource[aclResource]['conditions'] = conditions;
             //TODO: We probably shouldn't use this approach here:
             Config.Resource[aclResource]['graph'] = g;
             return g;
@@ -1823,7 +1837,7 @@ export function getAccessSubjects (authorizations, options) {
 export function getAuthorizationsMatching (g, matchers) {
   var authorizations = {};
 
-  const authorizationProperties = ['agent', 'agentClass', 'agentGroup', 'accessTo', 'default', 'mode', 'origin'];
+  const authorizationProperties = ['agent', 'agentClass', 'agentGroup', 'accessTo', 'default', 'mode', 'origin', 'condition'];
 
   // console.log("getAuthorizationsMatching:", g.terms, g.out().values, matchers);
 
@@ -1855,8 +1869,24 @@ export function getAuthorizationsMatching (g, matchers) {
       if (allKeysMatched) {
         var authorization = {};
 
+        // https://solidproject.org/TR/2024/wac-20240512#authorization-rule
+        // https://solid.github.io/web-access-control-spec/#access-mode-extensions
+        // https://solid.github.io/web-access-control-spec/#access-condition-extensions
         authorizationProperties.forEach(p => {
           authorization[p] = s.out(ns.acl[p]).values;
+
+          if (p === 'condition' && authorization[p].length) {
+            authorization[p] = authorization[p].map(term => {
+              const conditionNode = isUrl(term) ? s.node(rdf.namedNode(term)) : s.node(rdf.blankNode(term));
+              const triples = { id: term };
+              conditionNode.out().quads().forEach(quad => {
+                const pred = quad.predicate.value;
+                if (!triples[pred]) triples[pred] = [];
+                triples[pred].push(quad.object.value);
+              });
+              return triples;
+            });
+          }
         })
 
         authorizations[authorizationIRI] = authorization;


### PR DESCRIPTION
Implements:

* https://solid.github.io/web-access-control-spec/#client-link-condition
* https://solid.github.io/web-access-control-spec/#access-conditions
* https://solid.github.io/web-access-control-spec/#access-condition-extensions

If a server doesn't support conditions, dokieli will not write any conditions.

If a server supports conditions (via link header), dokieli can discover them. Dokieli will process the effective ACL resource for conditions and tracks the values.

When user updates someone's access permissions (from the Share feature), it only adds `acl:clientClass foaf:Agent` since we don't wish to limit the use of resources only to dokieli.

It will preserve existing conditions, e.g., when need to preserve existing conditions from an effective ACL resource that is a container towards the new ACL resource that needs to be created.

Dokieli doesn't write `acl:IssuerCondition` at the moment but will implement this in the future once environment variables are put in place for specific dokieli deployments.

There is no change to the UI.