### PR TITLE
Integrate @dokieli/web-annotation module for annotations

### DIFF
--- a/locales/en-GB/translations.json
+++ b/locales/en-GB/translations.json
@@ -1,7 +1,10 @@
 {
   "annotation-inbox.label.textContent": "Inbox",
+  "annotation-location-selection.not-found.p.textContent": "Location to store annotation not found. Please ensure you have a place to store your annotation, re-signin, and try again.",
   "annotation-location-selection.store-at.span.textContent": "Store at:",
   "annotation-location.annotation-service.label.textContent": "Annotation service",
+  "annotation-location.annotation-store.label.textContent": "Annotations store",
+  "annotation-location.activity-outbox.label.textContent": "Activity outbox",
   "annotation-location.personal-storage.label.textContent": "Personal storage",
   "annotation.delete.button.aria-label": "Delete annotation",
   "annotation.delete.button.title": "Delete",

--- a/locales/en-US/translations.json
+++ b/locales/en-US/translations.json
@@ -1,8 +1,11 @@
 {
   "annotation-inbox.label.textContent": "Inbox",
+  "annotation-location-selection.not-found.p.textContent": "Location to store annotation not found. Please ensure you have a place to store your annotation, re-signin, and try again.",
   "annotation-location-selection.store-at.span.textContent": "Store at:",
   "annotation-location.annotation-service.label.textContent": "Annotation service",
+  "annotation-location.annotation-store.label.textContent": "Annotations store",
   "annotation-location.personal-storage.label.textContent": "Personal storage",
+  "annotation-location.activity-outbox.label.textContent": "Activity outbox",
   "annotation.delete.button.aria-label": "Delete annotation",
   "annotation.delete.button.title": "Delete",
   "browser.browse-location.button.textContent": "Browse",

--- a/media/css/dokieli.css
+++ b/media/css/dokieli.css
@@ -2278,7 +2278,8 @@ aside.note .language,
 aside.note .renderedvia,
 aside.note .rights,
 aside.note .license,
-aside.note .canonical {
+aside.note .canonical,
+aside.note .format {
 display:none;
 }
 
@@ -4178,7 +4179,6 @@ button[type="button"]:focus {
   button {
   width: max-content;
   max-width: fit-content;
-  cursor: pointer;
   }
   button:nth-of-type(1) {
   grid-area: button1
@@ -4653,7 +4653,7 @@ line-height:1;
 }
 .editor-form .annotation-inbox,
 .editor-form .annotation-location-selection {
-margin: 0 1em 0 1em;
+margin: 0.25em 1em 0 1em;
 vertical-align: top;
 }
 .editor-form .annotation-inbox {
@@ -4661,6 +4661,42 @@ margin-left:0;
 }
 .editor-form input:nth-of-type(2):before {
 margin-left: 68px;
+}
+.editor-form .annotation-location-details > summary {
+cursor: pointer;
+font-weight: bold;
+}
+.editor-form .annotation-location-details ul {
+list-style: none;
+margin: 0.35em 0 0 0;
+padding: 0;
+}
+.editor-form .annotation-location-details li {
+display: flex;
+align-items: baseline;
+flex-wrap: wrap;
+gap: 0.4em;
+margin: 0.25em 0;
+}
+.editor-form .annotation-location-details li input {
+margin: 0;
+}
+.editor-form .annotation-location-details li input:before {
+margin-left: 0;
+}
+.editor-form .annotation-location-details li label {
+width: auto;
+font-size: 1em;
+line-height: 1;
+white-space: nowrap;
+}
+.editor-form .annotation-location-details code {
+font-size: 0.9em;
+color: #000;
+background-color:initial;
+overflow-wrap: anywhere;
+word-break: break-all;
+padding:0;
 }
 #ref-reference {
 margin-left:1.5em;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@dokieli/web-annotation": "^1.0.0",
     "@uvdsl/solid-oidc-client-browser": "^0.2.3",
     "buffer": "^6.0.3",
     "d3-force": "^3.0.0",

--- a/service-worker.js
+++ b/service-worker.js
@@ -12,7 +12,9 @@ const APP_FILES = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(APP_FILES))
+    caches.open(CACHE_NAME).then(cache =>
+      Promise.allSettled(APP_FILES.map(f => cache.add(f)))
+    )
   );
   self.skipWaiting();
 });

--- a/src/activity.js
+++ b/src/activity.js
@@ -16,20 +16,22 @@ limitations under the License.
 */
 
 import rdf from 'rdf-ext';
-import { createActivityHTML, showCitations, getReferenceLabel, createNoteDataHTML, handleDeleteNote } from './doc.js';
+import { createActivityHTML, createActivityJSONLD, showCitations, getReferenceLabel, createNoteDataHTML, handleDeleteNote } from './doc.js';
+import { applyMarksFromTextQuote, applyMarkFromSelector } from '@dokieli/web-annotation';
 var _deleteListenerAttached = false;
 import { createHTML } from './utils/html.js';
 import { Icon } from './ui/icons.js'
 import { getButtonHTML } from './ui/buttons.js'
 import { getAbsoluteIRI, getPathURL, isHttpOrHttpsProtocol, stripFragmentFromString, currentLocation, getFragmentFromString } from './uri.js';
-import { getLinkRelation, serializeDataToPreferredContentType, getGraphLanguage, getGraphLicense, getGraphRights, getGraphTypes, getGraphDate, getGraphImage, getResourceGraph, getResourceOnlyRDF, getAgentTypeIndex, getUserContacts, getAgentName, getSubjectInfo, getItemsList } from './graph.js';
+import { getLinkRelation, serializeDataToPreferredContentType, getGraphLanguage, getGraphLicense, getGraphRights, getGraphTypes, getGraphDate, getGraphImage, getResourceGraph, getResourceOnlyRDF, getAgentTypeIndex, getUserContacts, getAgentName, getSubjectInfo, getItemsList, parseAnnotationFromGraph } from './graph.js';
 import Config from './config.js';
 import { domSanitize, sanitizeInsertAdjacentHTML } from './utils/sanitization.js';
-import { generateUUID, uniqueArray, findPreviousDateTime } from './util.js';
+import { generateAttributeId, uniqueArray, findPreviousDateTime } from './util.js';
 import { fragmentFromString, getDocumentContentNode, selectArticleNode } from "./utils/html.js";
 import { getTextContentExcludingSups } from './editor/utils/annotation.js';
 import { i18n } from './i18n.js';
 import { showUserIdentityInput } from './auth.js';
+import { updateDeviceStorageProfile } from './storage.js';
 
 const ns = Config?.ns;
 
@@ -304,6 +306,11 @@ export function notifyInbox(o) {
     'profile': 'https://www.w3.org/ns/activitystreams'
   };
 
+  // Model-built JSON-LD for content-negotiated inboxes (avoids RDFa-derived langStrings).
+  if (o.note) {
+    options.activityJSONLD = createActivityJSONLD(o);
+  }
+
   return postActivity(inboxURL, slug, data, options);
 }
 export function postActivity(url, slug, data, options) {
@@ -346,7 +353,7 @@ export function registerAnnotationInTypeIndex(containerIRI, forClass) {
 
   _registeredTypeIndexKeys.add(forClass);
 
-  const registrationId = generateUUID();
+  const registrationId = generateAttributeId();
   const insert = `<#${registrationId}> a <http://www.w3.org/ns/solid/terms#TypeRegistration> ;\n` +
     `  <http://www.w3.org/ns/solid/terms#forClass> <${forClass}> ;\n` +
     `  <http://www.w3.org/ns/solid/terms#instanceContainer> <${containerIRI}> .\n`;
@@ -359,6 +366,8 @@ export function registerAnnotationInTypeIndex(containerIRI, forClass) {
         [ns.solid.forClass.value]: forClass,
         [ns.solid.instanceContainer.value]: containerIRI
       };
+      // Persist the new registration so it survives a refresh from device storage.
+      updateDeviceStorageProfile(Config.User);
     })
     .catch(e => console.log('Could not register annotation type in TypeIndex:', e));
 }
@@ -425,20 +434,25 @@ export function showNotificationSources(url) {
   );
 }
 
-export async function showActivitiesSources(url, options = {}) {
-  return getItemsList(url)
+async function showActivitiesSourcesUncached(url, options = {}) {
+  // The container listing itself gets rate-limited under load; retry it so today's
+  // annotations are actually enumerated instead of the whole scan coming up empty.
+  return withReadRetry(() => getItemsList(url))
     .then(items => {
-      var promises = [];
+      // Cap concurrency so a large collection doesn't fan out into dozens of parallel
+      // HEAD+GET fetches and trip the storage server's rate limiter (429).
+      var queue = items.slice(0, Config.CollectionItemsLimit);
+      var concurrency = Math.min(Config.CollectionItemsConcurrency, queue.length);
+      var cursor = 0;
 
-      for (var i = 0; i < items.length && i < Config.CollectionItemsLimit; i++) {
-        var pI = function(iri) {
-          return showActivities(iri, options);
+      var worker = async () => {
+        while (cursor < queue.length) {
+          var iri = queue[cursor++];
+          try { await showActivities(iri, options); } catch (e) {}
         }
+      };
 
-        promises.push(pI(items[i]));
-      }
-      // console.log(promises)
-      return Promise.allSettled(promises);
+      return Promise.all(Array.from({ length: concurrency }, worker));
     })
     .catch((error) => {
       console.log(error)
@@ -461,7 +475,95 @@ export async function showActivitiesSources(url, options = {}) {
 //   }
 // }
 
+// Global gate for activity/notification reads only. A document can fan out
+// into dozens of these at once (many callers, each looping), tripping storage
+// rate limiters (429) - which the browser surfaces as opaque CORS failures.
+// Bounding here (rather than in the fetcher) keeps the cap off the auth,
+// profile, and posting paths. The slot is held only for the duration of the
+// read, released before any recursive showActivities call, so there's no
+// nested-semaphore deadlock.
+let activityReadsActive = 0;
+const activityReadsQueue = [];
+
+function activityReadsDrain() {
+  while (activityReadsActive < Config.CollectionItemsConcurrency && activityReadsQueue.length) {
+    activityReadsActive++;
+    activityReadsQueue.shift()();
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Retries an activity read on failure with exponential backoff. The storage server
+// rate-limits bursts (429), which the browser usually surfaces as an opaque
+// CORS/network failure with no readable status - so retry on ANY rejection
+// (bounded), backing off to let the rate window clear. Honors Retry-After when the
+// 429 is actually readable. Run inside the read gate so backoff also frees a slot.
+async function withReadRetry(fn, attempts = 3) {
+  var delay = 600;
+  for (var i = 0; ; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (i >= attempts - 1) { throw error; }
+      var retryAfter = Number(error?.response?.headers?.get?.('Retry-After'));
+      var wait = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : delay;
+      await sleep(wait);
+      delay *= 2;
+    }
+  }
+}
+
+function gatedGetResourceOnlyRDF(url) {
+  return new Promise(resolve => {
+    activityReadsQueue.push(resolve);
+    activityReadsDrain();
+  }).then(() =>
+    withReadRetry(() => getResourceOnlyRDF(url)).finally(() => {
+      activityReadsActive--;
+      activityReadsDrain();
+    })
+  );
+}
+
+// Per-URL in-flight dedup for activity reads. A document fans out into many
+// overlapping scans (page load + every notifications-panel open; one
+// showActivitiesSources per type registration, often sharing a container; the
+// same annotation reachable via several activities), all hitting the same URLs.
+// Without this, those collapse onto the storage server at once and trip its rate
+// limiter (429), which the browser surfaces as opaque CORS failures - and the
+// duplicate processing also double-lists notes. Entries clear on settle, so a
+// later panel open still rescans (leaf annotations stay cached in Config.Activity,
+// so a rescan is cheap), while a single burst is collapsed to one fetch per URL.
+const showActivitiesInFlight = new Map();
+const showActivitiesSourcesInFlight = new Map();
+
 export function showActivities(url, options = {}) {
+  if (Config.Activity[url] || Config.Notification[url]) {
+    return Promise.reject([]);
+  }
+  if (showActivitiesInFlight.has(url)) {
+    return showActivitiesInFlight.get(url);
+  }
+  const p = showActivitiesUncached(url, options)
+    .finally(() => showActivitiesInFlight.delete(url));
+  showActivitiesInFlight.set(url, p);
+  return p;
+}
+
+export function showActivitiesSources(url, options = {}) {
+  if (showActivitiesSourcesInFlight.has(url)) {
+    return showActivitiesSourcesInFlight.get(url);
+  }
+  const p = showActivitiesSourcesUncached(url, options)
+    .finally(() => showActivitiesSourcesInFlight.delete(url));
+  showActivitiesSourcesInFlight.set(url, p);
+  return p;
+}
+
+function showActivitiesUncached(url, options = {}) {
   if (Config.Activity[url] || Config.Notification[url]) {
     return Promise.reject([]);
   }
@@ -470,7 +572,7 @@ export function showActivities(url, options = {}) {
 
   var documentTypes = Config.ActivitiesObjectTypes.concat(Object.keys(Config.ResourceType));
 
-  return getResourceOnlyRDF(url)
+  return gatedGetResourceOnlyRDF(url)
     //TODO: Needs throws handled from functions calling showActivities
     // .catch(e => {
     //   // return [];
@@ -526,7 +628,7 @@ export function showActivities(url, options = {}) {
                 var iri = s.term.value;
                 var targetIRI = object[0];
                 // var motivatedBy = 'oa:assessing';
-                var id = generateUUID(iri);
+                var id = generateAttributeId(iri);
                 var refId = 'r-' + id;
                 var refLabel = id;
 
@@ -536,7 +638,7 @@ export function showActivities(url, options = {}) {
                 var noteData = {
                   "type": bodyValue === 'Liked' ? 'approve' : 'disapprove',
                   "mode": "read",
-                  "motivatedByIRI": motivatedBy,
+                  "motivatedBy": motivatedBy,
                   "id": id,
                   "refId": refId,
                   "refLabel": refLabel,
@@ -727,7 +829,7 @@ export function showActivities(url, options = {}) {
             var iri = s.term.value;
             var targetIRI = s.out(ns.bookmark.recalls).values[0];
             var motivatedBy = 'bookmark:Bookmark';
-            var id = generateUUID(iri);
+            var id = generateAttributeId(iri);
             var refId = 'r-' + id;
             var refLabel = id;
 
@@ -736,7 +838,7 @@ export function showActivities(url, options = {}) {
             var noteData = {
               "type": 'bookmark',
               "mode": "read",
-              "motivatedByIRI": motivatedBy,
+              "motivatedBy": motivatedBy,
               "id": id,
               "refId": refId,
               "refLabel": refLabel,
@@ -998,7 +1100,50 @@ export async function positionInteraction(noteIRI, containerNode, options) {
   showAnnotation(noteIRI, g, containerNode, options);
 }
 
-export function showAnnotation(noteIRI, g, options) {
+// Finds the TextQuoteSelector within a typed Selector (annotations),
+// following oa:refinedBy (e.g. FragmentSelector → refinedBy → TextQuoteSelector).
+function textQuoteFromSelector(selector) {
+  if (!selector) { return undefined; }
+  if (selector.type === 'TextQuoteSelector') { return selector; }
+  if (selector.refinedBy) { return textQuoteFromSelector(selector.refinedBy); }
+  return undefined;
+}
+
+// Marks the annotated passage in the document at creation time, from the selector
+// dokieli already holds in memory. The re-fetch path (showActivities ->
+// showAnnotation) that normally draws the highlight needs a server round-trip,
+// which gets rate-limited (429) under load - so don't depend on it for the
+// just-created annotation. Idempotent: returns early if a mark for this annotation
+// already exists, so the re-fetch path (if it later succeeds) won't double-mark.
+export function markAnnotationTarget(noteIRI, selector, options = {}) {
+  if (!noteIRI || !selector) { return null; }
+
+  var containerNode = selectArticleNode(document);
+  if (!containerNode) { return null; }
+
+  // The annotation link now lives on the reference marker, so detect an existing mark by it.
+  if (containerNode.querySelector('[resource="' + noteIRI + '"]')) { return null; }
+
+  var motivatedBy = options.motivatedBy || 'oa:replying';
+  var id = options.id || generateAttributeId(noteIRI);
+  var refLabel = options.refLabel || getReferenceLabel(motivatedBy);
+  var docRefType = '<sup class="ref-annotation"><a href="#' + id + '" rel="cito:hasReplyFrom" resource="' + noteIRI + '">' + refLabel + '</a></sup>';
+
+  var markOptions = { 'annotationUrl': noteIRI, 'id': 'r-' + id, 'className': 'ref do', 'reference': docRefType, 'excludeMatchesIn': '#document-notifications', 'ignoreSelector': 'sup' };
+
+  // Cross-node selections use a RangeSelector (XPath start/end refined by TextQuotes);
+  // applyMarkFromSelector resolves it to a range and marks each text node it spans.
+  // A plain TextQuoteSelector marks every matching occurrence.
+  var isTextQuote = selector.type === 'TextQuoteSelector' || (!selector.type && selector.exact);
+  if (isTextQuote) {
+    if (!selector.exact) { return null; }
+    return applyMarksFromTextQuote(containerNode, { exact: selector.exact, prefix: selector.prefix, suffix: selector.suffix }, markOptions);
+  }
+
+  return applyMarkFromSelector(containerNode, selector, markOptions);
+}
+
+export async function showAnnotation(noteIRI, g, options) {
   // Use the document content node (main > article or main) rather than document.body
   // so that the notifications panel aside is excluded from text searches.
   var containerNode = selectArticleNode(document);
@@ -1014,7 +1159,7 @@ export function showAnnotation(noteIRI, g, options) {
   // console.log(note.toString())
   // console.log(note)
 
-  var id = generateUUID(noteIRI);
+  var id = generateAttributeId(noteIRI);
   var refId = 'r-' + id;
   var refLabel = id;
 
@@ -1181,39 +1326,28 @@ export function showAnnotation(noteIRI, g, options) {
       refLabel = getReferenceLabel(motivatedBy);
     }
 
-    var exact, prefix, suffix;
-    var selectorPtr = targetPtr.out(ns.oa.hasSelector);
-    var selector = selectorPtr.values[0];
-    if (selector) {
-      // selectorPtr already points at the selector node - no need to re-lookup by IRI
-      // console.log(selectorPtr);
+    // Resolve the selector via @dokieli/web-annotation's parser (rdf-ext graph →
+    // JSON-LD → Annotation). Core resolves the typed selector tree, including
+    // FragmentSelector → refinedBy → TextQuoteSelector, so we no longer walk it
+    // by hand. `parsedSelector` is the typed Selector union from core.
+    var exact, prefix, suffix, selector;
+    var parsedAnnotation = await parseAnnotationFromGraph(g, note.value || noteIRI);
+    var parsedSelector = parsedAnnotation?.target?.selector;
 
-      // console.log(selectorPtr.out(ns.rdf.type).values);
-      //FIXME: This is taking the first rdf:type. There could be multiple.
-      var selectorTypes = getGraphTypes(selectorPtr)[0];
-      // console.log(selectorTypes)
-      // console.log(selectorTypes == 'http://www.w3.org/ns/oa#FragmentSelector');
-      if (selectorTypes == ns.oa.TextQuoteSelector.value) {
-        exact = selectorPtr.out(ns.oa.exact).values[0];
-        prefix = selectorPtr.out(ns.oa.prefix).values[0];
-        suffix = selectorPtr.out(ns.oa.suffix).values[0];
-      }
-      else if (selectorTypes == ns.oa.FragmentSelector.value) {
-        var refinedByPtr = selectorPtr.out(ns.oa.refinedBy);
-        // console.log(refinedByPtr)
-        exact = refinedByPtr.out(ns.oa.exact).values[0];
-        prefix = refinedByPtr.out(ns.oa.prefix).values[0];
-        suffix = refinedByPtr.out(ns.oa.suffix).values[0];
-        // console.log(selectorPtr.rdfvalue)
-        if (selectorPtr.out(ns.rdf.value).values[0] && selectorPtr.out(ns.dcterms.conformsTo).values[0] && selectorPtr.out(ns.dcterms.conformsTo).values[0].endsWith('://tools.ietf.org/html/rfc3987')) {
-          var fragment = selectorPtr.out(ns.rdf.value).values[0];
-          // console.log(fragment)
-          fragment = (fragment.indexOf('#') == 0) ? getFragmentFromString(fragment) : fragment;
+    var textQuote = textQuoteFromSelector(parsedSelector);
+    if (textQuote) {
+      exact = textQuote.exact;
+      prefix = textQuote.prefix;
+      suffix = textQuote.suffix;
+    }
 
-          if (fragment !== '') {
-            containerNode = document.getElementById(fragment) || selectArticleNode(document);
-          }
-        }
+    if (parsedSelector?.type === 'FragmentSelector' && parsedSelector.value
+        && parsedSelector.conformsTo && parsedSelector.conformsTo.endsWith('://tools.ietf.org/html/rfc3987')) {
+      var fragment = parsedSelector.value;
+      fragment = (fragment.indexOf('#') == 0) ? getFragmentFromString(fragment) : fragment;
+
+      if (fragment !== '') {
+        containerNode = document.getElementById(fragment) || selectArticleNode(document);
       }
     }
     // console.log(exact);
@@ -1237,15 +1371,25 @@ export function showAnnotation(noteIRI, g, options) {
         "suffix": suffix
       };
 
-      var selectedParentNode = Config.Editor.importTextQuoteSelector(containerNode, selector, refId, motivatedBy, docRefType, { 'do': true });
+      // ignoreSelector excludes prior annotations' <sup> reference markers from the
+      // library's text basis, matching getTextContentExcludingSups used above so the
+      // offsets agree. Without it, a marker landing inside the phrase breaks the match.
+      var markOptions = { 'annotationUrl': noteIRI, 'id': refId, 'className': 'ref do', 'reference': docRefType, 'excludeMatchesIn': '#document-notifications', 'ignoreSelector': 'sup' };
+      // Don't re-mark if the passage was already marked at creation time (detect by the reference link).
+      var existingMark = containerNode.querySelector('[resource="' + noteIRI + '"]');
+      var selectedParentNode = existingMark
+        ? existingMark.closest('[id]')
+        : (textQuote
+          ? applyMarksFromTextQuote(containerNode, selector, markOptions)
+          : (parsedSelector ? applyMarkFromSelector(containerNode, parsedSelector, markOptions) : null));
 
-      var parentNodeWithId = selectedParentNode.closest('[id]');
+      var parentNodeWithId = selectedParentNode?.closest('[id]');
       targetIRI = (parentNodeWithId) ? documentURL + '#' + parentNodeWithId.id : documentURL;
       // console.log(parentNodeWithId, targetIRI)
       var noteData = {
         "type": 'comment',
         "mode": "read",
-        "motivatedByIRI": motivatedBy,
+        "motivatedBy": motivatedBy,
         "id": id,
         "refId": refId,
         "iri": noteIRI, //e.g., https://example.org/path/to/article
@@ -1312,7 +1456,7 @@ export function showAnnotation(noteIRI, g, options) {
       noteData = {
         "type": 'comment',
         "mode": "read",
-        "motivatedByIRI": motivatedBy,
+        "motivatedBy": motivatedBy,
         "id": id,
         "refId": refId,
         "refLabel": refLabel,
@@ -1372,13 +1516,13 @@ export function showAnnotation(noteIRI, g, options) {
       noteData = {
         "type": 'comment',
         "mode": "read",
-        "motivatedByIRI": motivatedBy,
+        "motivatedBy": motivatedBy,
         "id": id,
         "refId": refId,
         "refLabel": refLabel,
         "iri": noteIRI,
         "creator": {},
-        "inReplyTo": {
+        "target": {
           'iri': inReplyTo,
           'rel': inReplyToRel
         }

--- a/src/auth.js
+++ b/src/auth.js
@@ -727,13 +727,25 @@ export function setUserInfo (subjectIRI, options = {}) {
   Config.User.IRI = subjectIRI;
 
   return getSubjectInfo(subjectIRI, options).then(subject => {
+    setPreferredLanguagesInfo(subject.Graph);
+
+    const restoredTypeIndex = Config.User.TypeIndex;
+    const restoredHasRegistrations = restoredTypeIndex && Object.values(restoredTypeIndex).some(v => v && Object.keys(v).length > 0);
+
     Object.keys(subject).forEach((key) => {
       Config.User[key] = subject[key];
     })
 
-    setPreferredLanguagesInfo(subject.Graph);
+    // getSubjectInfo returns an empty TypeIndex (registrations are fetched later by
+    // afterSetUserInfo). Don't let it clobber registrations already restored from
+    // device storage, otherwise a refresh drops them until the fetch re-runs.
+    const fetchedTypeIndex = subject.TypeIndex;
+    const fetchedHasRegistrations = fetchedTypeIndex && Object.values(fetchedTypeIndex).some(v => v && Object.keys(v).length > 0);
+    if (restoredHasRegistrations && !fetchedHasRegistrations) {
+      Config.User.TypeIndex = restoredTypeIndex;
+    }
 
-    updateDeviceStorageProfile(subject);
+    updateDeviceStorageProfile(Config.User);
   });
 }
 
@@ -758,9 +770,20 @@ export function afterSetUserInfo() {
   if (Config.User.Graph) {
     promises.push(getAgentTypeIndex(Config.User.Graph)
       .then(typeIndexes => {
+        Config.User.TypeIndex = Config.User.TypeIndex || {};
+        // Only overwrite a type index we actually fetched registrations for, so a
+        // transient empty fetch (e.g. auth not ready on refresh) doesn't drop the
+        // registrations already restored from device storage.
+        let changed = false;
         Object.keys(typeIndexes).forEach(typeIndexType => {
-          Config.User.TypeIndex[typeIndexType] = typeIndexes[typeIndexType];
+          if (typeIndexes[typeIndexType] && Object.keys(typeIndexes[typeIndexType]).length > 0) {
+            Config.User.TypeIndex[typeIndexType] = typeIndexes[typeIndexType];
+            changed = true;
+          }
         });
+        // Persist right after fetching so a refresh restores the registrations from
+        // device storage instead of relying on the fetch re-running.
+        if (changed) { updateDeviceStorageProfile(Config.User); }
       }));
 
     promises.push(getAgentPreferencesInfo(Config.User.Graph)

--- a/src/config.js
+++ b/src/config.js
@@ -264,6 +264,7 @@ export default {
     'references': { 'label': 'References', 'selector':'cite a', 'titleSelector': 'h2' }
   },
   CollectionItemsLimit: 50,
+  CollectionItemsConcurrency: 2,
   ContextLength: 32,
   NotificationLicense: 'https://creativecommons.org/publicdomain/zero/1.0/',
   License: {

--- a/src/csv.js
+++ b/src/csv.js
@@ -17,7 +17,7 @@ limitations under the License.
 
 import Config from './config.js'
 import Papa from 'papaparse';
-import { generateUUID, getDateTimeISO } from './util.js';
+import { generateAttributeId, getDateTimeISO } from './util.js';
 import { sanitizeObject, domSanitize } from './utils/sanitization.js';
 import { createDateHTML, createLicenseHTML } from './doc.js';
 import uriTemplates from 'uri-templates';
@@ -91,7 +91,7 @@ export function jsonToHtmlTableString(csvTables, metadata = {}) {
     let licenseHTML = license ? createLicenseHTML(license["@id"], {rel:'dcterms:license', label:'License'}) : '';
     let modifiedHTML = modified ? createDateHTML({ 'property': 'dcterms:modified', 'title': 'Modified', 'datetime': new Date(tableMetadata ? tableMetadata['dcterms:modified']["@value"] : null) }) : '';
 
-    const activityGeneratedBy = generateUUID();
+    const activityGeneratedBy = generateAttributeId();
     const activityStartedAt = getDateTimeISO();
 
     const metadataColumns = tableMetadata?.tableSchema?.columns;
@@ -331,7 +331,7 @@ function generateProvenance (csvUrl, metadataUrl, activityGeneratedBy, activityS
 
   if (metadataUrl) {
     csvwTabularMetadataHTML = `            
-            <dl resource="#${generateUUID()}" typeof="prov:Usage">
+            <dl resource="#${generateAttributeId()}" typeof="prov:Usage">
               <dt>Entity</dt>
               <dd><a href="${metadataUrl}" rel="prov:entity">${metadataUrl}</a></dd>
               <dt>Role</dt>
@@ -352,7 +352,7 @@ function generateProvenance (csvUrl, metadataUrl, activityGeneratedBy, activityS
           <dd><time datetime="${activityEndedAt}" property="prov:endedAtTime">${activityEndedAt}</time></dd>
           <dt>Usage</dt>
           <dd rel="prov:qualifiedUsage">
-            <dl resource="#${generateUUID()}" typeof="prov:Usage">
+            <dl resource="#${generateAttributeId()}" typeof="prov:Usage">
               <dt>Entity</dt>
               <dd><a href="${csvUrl}" rel="prov:entity">${csvUrl}</a></dd>
               <dt>Role</dt>

--- a/src/cv.js
+++ b/src/cv.js
@@ -20,7 +20,7 @@ import { fragmentFromString, selectArticleNode } from './utils/html.js';
 import { slugify } from './editor/plugins/autoId.js';
 import { registerDocumentTransform, registerEditorParseTransform } from './utils/documentTransforms.js';
 import { i18n } from './i18n.js';
-import { generateAttributeId, generateUUID } from './util.js';
+import { generateAttributeId } from './util.js';
 import { getCountryOptionsHTML, showLocationSuggestions, showSkillSuggestions, setupAutocomplete } from './doc.js';
 import { getWikidataResults, getEscoResults } from './graph.js';
 import { expandTerm, getPrefixes, collectTerms } from './utils/rdfa.js';

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -21,9 +21,10 @@ import { i18n } from './i18n.js';
 import { getButtonHTML, updateButtons, setMenuButtonDisabled } from './ui/buttons.js';
 import { addMessageToLog, buildResourceView, copyRelativeResources, createFeedXML, createImmutableResource, createMutableResource, createNoteDataHTML, getAccessModeOptionsHTML, getBaseURLSelection, getDocument, getFeedFormatSelection, getLanguageOptionsHTML, getLicenseOptionsHTML, getResourceInfo, getSavePayload, isMarkdownTarget, rewriteBaseURL, setCopyToClipboard, setDocumentRelation, showActionMessage, showRobustLinksDecoration, showTimeMap, updateMutableResource, buildReferences, getDocumentConceptDefinitionsHTML, insertDocumentLevelHTML, insertTestCoverageToTable, diffRequirements, removeReferences, getStorageSelfDescription, getContactInformation, getPersistencePolicy, getODRLPolicies, updateResourceInfos, initCurrentStylesheet, setDate, showFragment, initCopyToClipboard, setDocumentURL, getAgentHTML } from './doc.js';
 import { removeNodesWithIds, createHTML, getFormValues } from './utils/html.js';
+import { createAnnotation } from '@dokieli/web-annotation';
 import { accessModeAllowed, accessModePossiblyAllowed } from './access.js';
 import { domSanitize, sanitizeInsertAdjacentHTML, sanitizeIRI, sanitizeObject, htmlEncode, sanitizeIRIs } from './utils/sanitization.js';
-import { escapeRDFLiteral, generateAttributeId, generateUUID } from './util.js';
+import { escapeRDFLiteral, generateAttributeId } from './util.js';
 import { setAcceptRDFTypes } from './fetcher.js';
 import { forceTrailingSlash, generateDataURI, getAbsoluteIRI, getBaseURL, isHttpOrHttpsProtocol, isFileProtocol, isUrl, stripFragmentFromString, getFragmentFromString, getURLLastPath, currentLocation } from './uri.js';
 import { getAccessSubjects, getACLResourceGraph, getAgentInbox, getAgentName, getAuthorizationsMatching, getGraphAuthors, getGraphContributors, getGraphEditors, getGraphImage, getGraphLabelOrIRI, getGraphPerformers, getGraphTypes, getLinkRelation, getLinkRelationFromHead, getResourceGraph, getUserContacts, getUserLabelOrIRI, serializeData, getSubjectInfo, getRDFSerializer } from './graph.js';
@@ -1531,31 +1532,25 @@ export function replyToResource(e, iri) {
     var attributeId = generateAttributeId()
 
     var motivatedBy = "oa:replying"
-    var noteData = {
-      "type": 'comment',
-      "mode": "write",
-      "motivatedByIRI": motivatedBy,
-      "id": attributeId,
-      // "iri": noteIRI, //e.g., https://example.org/path/to/article
-      "creator": {},
-      "datetime": datetime,
-      "target": {
-        "iri": iri
-      },
-      "body": [{ "value": note }],
-    }
-    if (Config.User.IRI) {
-      noteData.creator["iri"] = Config.User.IRI
-    }
-    if (Config.User.Name) {
-      noteData.creator["name"] = Config.User.Name
-    }
-    if (Config.User.Image) {
-      noteData.creator["image"] = Config.User.Image
-    }
-    if (Config.User.URL) {
-      noteData.creator["url"] = Config.User.URL
-    }
+    // dokieli maps its "reply" action to the oa:replying motivation and passes
+    // it directly to createAnnotation.
+    var noteData = createAnnotation({
+      motivatedBy,
+      type: 'comment',
+      id: attributeId,
+      refId: 'r-' + attributeId,
+      datetime,
+      target: { iri, renderedVia: { iri: 'https://dokie.li/#i', name: 'dokieli' } },
+      body: { content: note },
+      creator: {
+        iri: Config.User.IRI || undefined,
+        name: Config.User.Name || undefined,
+        image: Config.User.Image || undefined,
+        url: Config.User.URL || undefined,
+        type: Config.User.Types || undefined
+      }
+    })
+    noteData.mode = 'write'
 
     var language = document.querySelector('#reply-to-resource-language')
     if (language && language.length) {
@@ -1634,6 +1629,7 @@ export function replyToResource(e, iri) {
           "type": ['as:Announce'],
           "inbox": inboxURL,
           "object": noteIRI,
+          "note": Object.assign({}, noteData, { "iri": noteIRI }),
           "target": iri,
           "license": noteData.license,
           "statements": notificationStatements
@@ -2482,7 +2478,7 @@ function showCreateContainer(baseURL, id, action, e) {
   if (!e) {
     return;
   }
-  id = id || generateUUID();
+  id = id || generateAttributeId();
 
   var div = document.getElementById(id + '-create-container');
   if (div) {
@@ -4014,7 +4010,7 @@ export async function saveAsDocument(e) {
 
         if (Config.User.IRI && requestAccess) {
           document.querySelector('#save-as-document .response-message .request-access').addEventListener('click', (e) => {
-            var objectId = '#' + generateUUID();
+            var objectId = '#' + generateAttributeId();
 
             inboxURL = e.target.dataset.inbox;
             var accessTo = e.target.dataset.target;
@@ -4322,7 +4318,7 @@ function relayoutIfSingle() {
 }
 
 function newSlideFragment(template = 'normal') {
-  const id = 'slide-' + generateUUID();
+  const id = 'slide-' + generateAttributeId();
   const wrapper = (inner) => `<section class="slide" id="${id}" inlist="" rel="schema:hasPart" resource="#${id}" typeof="bibo:Slide">${inner}</section>`;
   switch (template) {
     case 'shout':
@@ -5242,7 +5238,7 @@ export function snapshotAtEndpoint(e, iri, endpoint, noteData, options = {}) {
       noteData = noteData || {
         "url": iri,
         "annotation": {
-          "@context": "http://www.w3.org/ns/anno.jsonld",
+          "@context": "https://www.w3.org/ns/anno.jsonld",
           "@type": "Annotation",
           "motivation": "linking",
           "target": iri,
@@ -6095,7 +6091,7 @@ export function processNotificationChannelMessage(data, options) {
 //     "https://www.w3.org/ns/activitystreams",
 //     "https://www.w3.org/ns/solid/notification/v1"
 //   ],
-//   "id": "urn:uuid:" + generateUUID(),
+//   "id": "urn:uuid:" + generateAttributeId(),
 //   "type": "Update",
 //   "object": "https://csarven.localhost:8443/foo.html",
 //   "state": "128f-MtYev",

--- a/src/doc.js
+++ b/src/doc.js
@@ -20,7 +20,7 @@ import * as Slideshow from './slideshow.js';
 import { diffChars } from 'diff';
 import LinkHeader from "http-link-header";
 import Config from './config.js'
-import { getDateTimeISO, generateAttributeId, uniqueArray, generateUUID, matchAllIndex, getRandomIndex, getHash, isValidISBN, getDateTimeISOFromMDY, debounce } from './util.js'
+import { getDateTimeISO, generateAttributeId, uniqueArray, matchAllIndex, getRandomIndex, getHash, isValidISBN, getDateTimeISOFromMDY, debounce } from './util.js'
 import { getAbsoluteIRI, getBaseURL, stripFragmentFromString, getFragmentFromString, getURLLastPath, getPrefixedNameFromIRI, generateDataURI, getProxyableIRI, getFragmentOrLastPath, currentLocation } from './uri.js'
 import { getResourceGraph, sortGraphTriples, getGraphContributors, getGraphAuthors, getGraphEditors, getGraphPerformers, getGraphPublishers, getGraphLabel, getGraphEmail, getGraphTitle, getGraphConceptLabel, getGraphPublished, getGraphUpdated, getGraphDescription, getGraphLicense, getGraphRights, getGraphFromData, getGraphAudience, getGraphTypes, getGraphLanguage, getGraphInbox, getUserLabelOrIRI, getGraphImage, getGraphDate, processResources, getAgentName } from './graph.js';
 import { Icon } from './ui/icons.js';
@@ -31,6 +31,8 @@ import { applyDocumentTransforms } from './utils/documentTransforms.js';
 import { formatHTML, fragmentFromString, getDoctype, getDocumentContentNode, selectArticleNode, getDocumentNodeFromString, stringFromFragment, createHTML, getOffset, htmlToMarkdown } from './utils/html.js';
 import { i18n } from './i18n.js';
 import { rewriteBlobImagesToRelative, uploadBlobAssets, clearBlobAssets, hasUploadTarget } from './editor/utils/imageAssets.js';
+import { serializeAnnotationToHTML, serializeAnnotationToJSONLD } from '@dokieli/web-annotation';
+import { renderFootnote, renderCitation } from './editor/utils/reference-render.js';
 
 const ns = Config.ns;
 
@@ -424,328 +426,127 @@ export function createActivityHTML(o) {
   return data
 }
 
-export function createNoteDataHTML(n) {
-  // console.log(n);
-  var created = '';
-  var lang = '', xmlLang = '', language = '';
-  var license = '';
-  var rights = '';
-  var creator = '', authors = '', creatorImage = '', creatorNameIRI = '', creatorURLNameIRI = '';
-  var hasTarget = '', annotationTextSelector = '', target = '';
-  var inbox = '';
-  var heading, hX;
-  var aAbout = '', aPrefix = '';
-  var noteType = '';
-  var body = '';
-  var buttonDelete = '';
-  var note = '';
-  var targetLabel = '';
-  var bodyAltLabel = '';
-  var articleClass = '';
-  var prefixes = ' prefix="' + Config.prefixStrings.annotation + '"';
+// AS activity as a JSON-LD object. When o.note (the annotation model) is present its
+// object is the library's clean JSON-LD (serializeAnnotationToJSONLD, no RDFa-derived
+// langStrings); otherwise the object is the annotation IRI. Notification wrapping is
+// dokieli's responsibility; the library only serializes the annotation.
+export function createActivityJSONLD(o) {
+  const localName = (t) => (typeof t === 'string' && t.includes(':') ? t.split(':')[1] : t);
 
-  var canonicalId = n.canonical || 'urn:uuid:' + generateUUID();
+  const activity = {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    type: (o.type || []).map(localName),
+    updated: getDateTimeISO()
+  };
 
-  var motivatedByIRI = n.motivatedByIRI || '';
-  var motivatedByLabel = '';
+  if (Config.User.IRI) { activity.actor = Config.User.IRI; }
 
-  motivatedByIRI = getPrefixedNameFromIRI(motivatedByIRI);
-
-  switch (motivatedByIRI) {
-    case 'oa:replying': default:
-      motivatedByIRI = 'oa:replying';
-      motivatedByLabel = 'replies';
-      targetLabel = 'In reply to';
-      bodyAltLabel = 'Replied';
-      aAbout = ('mode' in n && n.mode == 'object') ? '#' + n.id : '';
-      aPrefix = prefixes;
-      break;
-    case 'oa:assessing':
-      motivatedByLabel = 'reviews';
-      targetLabel = 'Review of';
-      bodyAltLabel = 'Reviewed';
-      aAbout = ('mode' in n && n.mode == 'object') ? '#' + n.id : '';
-      aPrefix = prefixes;
-      break;
-    case 'oa:questioning':
-      motivatedByLabel = 'questions';
-      targetLabel = 'Questions';
-      bodyAltLabel = 'Questioned';
-      aAbout = ('mode' in n && n.mode == 'object') ? '#' + n.id : '';
-      aPrefix = prefixes;
-      break;
-    case 'oa:describing':
-      motivatedByLabel = 'describes';
-      targetLabel = 'Describes';
-      bodyAltLabel = 'Described'
-      aAbout = '#' + n.id;
-      break;
-    case 'oa:commenting':
-      motivatedByLabel = 'comments';
-      targetLabel = 'Comments on';
-      bodyAltLabel = 'Commented';
-      aAbout = '#' + n.id;
-      break;
-    case 'oa:bookmarking': case 'bookmark:Bookmark':
-      motivatedByLabel = 'bookmarks';
-      targetLabel = 'Bookmarked';
-      bodyAltLabel = 'Bookmarked';
-      aAbout = ('mode' in n && n.mode == 'object') ? '#' + n.id : '';
-      aPrefix = prefixes;
-      break;
-    case 'as:Like':
-      motivatedByLabel = 'Liked';
-      targetLabel = 'Like of';
-      bodyAltLabel = 'Liked';
-      aAbout = ('mode' in n && n.mode == 'object') ? '#' + n.id : '';
-      aPrefix = prefixes;
-      break;
-    case 'as:Dislike':
-      motivatedByLabel = 'Disliked';
-      targetLabel = 'Dislike of';
-      bodyAltLabel = 'Disliked';
-      aAbout = ('mode' in n && n.mode == 'object') ? '#' + n.id : '';
-      aPrefix = prefixes;
-      break;
+  if (o.note) {
+    activity.object = serializeAnnotationToJSONLD(o.note);
+  } else if (o.object) {
+    activity.object = o.object;
   }
 
-  switch (n.mode) {
-    default: case 'read':
-      hX = 3;
-      if ('creator' in n && 'iri' in n.creator && n.creator.iri == Config.User.IRI) {
-        buttonDelete = '<button aria-label="Delete item" class="delete do" title="Delete item" type="button">' + Icon[".fas.fa-trash-alt"] + '</button>';
-      }
-      // articleClass = (motivatedByIRI == 'oa:commenting') ? '' : ' class="do"';
-      aAbout = ('iri' in n) ? n.iri : aAbout;
-      break;
-    case 'write':
-      hX = 1;
-      break;
-    case 'object':
-      hX = 2;
-      break;
-  }
+  if (o.target && o.target.length) { activity.target = o.target; }
+  if (o.context && o.context.length) { activity.context = o.context; }
+  if (o.inReplyTo) { activity.inReplyTo = o.inReplyTo; }
+  if (o.summary && o.summary.length) { activity.summary = o.summary; }
+  if (o.content && o.content.length) { activity.content = o.content; }
+  if (o.to && typeof o.to === 'string' && /^https?:\/\//i.test(o.to) && !/\s/.test(o.to)) { activity.to = o.to; }
 
-  var creatorName = '';
-  var creatorIRI = '#' + generateAttributeId();
+  return activity;
+}
 
-  if ('creator' in n) {
-    if ('iri' in n.creator) {
-      creatorIRI = n.creator.iri;
+const OBJECT_ABOUT_MOTIVATIONS = new Set([
+  'oa:replying', 'oa:assessing', 'oa:questioning', 'oa:bookmarking', 'as:Like', 'as:Dislike'
+]);
+
+// dokieli maps its render context (n.mode) and ownership onto serialize options,
+// then delegates HTML generation to @dokieli/web-annotation. The library is
+// presentation-agnostic: dokieli decides the heading level and RDFa subject,
+// supplies license display names and avatar/name resolution, and injects the
+// delete control (a UI affordance the library does not emit).
+export function createNoteDataHTML(n, serializerOptions = {}) {
+  const mode = n.mode || 'write';
+  const headingLevel = mode === 'read' ? 3 : mode === 'object' ? 2 : 1;
+
+  const options = {
+    headingLevel,
+    about: getAnnotationAbout(n, mode),
+    labels: getAnnotationLabels(),
+    licenses: Config.License,
+    resolveImage: (creator) => resolveAnnotationAvatar(creator, mode),
+    resolveName: (creator) => creator.name || (creator.iri ? getUserLabelOrIRI(creator.iri) : undefined),
+    resolveLanguageName: (code) => {
+      const entry = Config.Languages[code] || Config.Languages[code.split('-')[0]];
+      return entry ? entry.sourceName : undefined;
+    },
+    ...serializerOptions
+  };
+
+  // Embedded reference kinds are dokieli document composition, rendered here; everything
+  // else goes through the library's uniform annotation serialization.
+  let note;
+  if (n.type === 'ref-footnote') {
+    note = renderFootnote(n);
+  } else if (n.type === 'ref-citation') {
+    note = renderCitation(n, options);
+  } else {
+    note = serializeAnnotationToHTML(n, options);
+    // The library renders no avatar without an image. dokieli shows an anonymous
+    // placeholder (no rel, so display-only and never in the graph) for such creators.
+    if (n.creator && !resolveAnnotationAvatar(n.creator, mode)) {
+      const placeholder = '<img alt="" height="48" src="' + Config.IconBase64['.fas.fa-user-secret'] + '" width="48" /> ';
+      note = note.replace(/(<span rel="dcterms:creator"><span about="[^"]*"[^>]*>)/, '$1' + placeholder);
     }
-
-    creatorName = creatorIRI;
-
-    if ('name' in n.creator) {
-      creatorName = n.creator.name;
-      creatorNameIRI = '<span about="' + creatorIRI + '" property="schema:name">' + creatorName + '</span>';
-    }
-    else {
-      creatorName = getUserLabelOrIRI(creatorIRI);
-      creatorNameIRI = (creatorName == creatorIRI) ? creatorName : '<span about="' + creatorIRI + '" property="schema:name">' + creatorName + '</span>';
-    }
-
-    var img = Config.IconBase64['.fas.fa-user-secret'];
-    if ('image' in n.creator) {
-      img = (n.mode == 'read') ? getProxyableIRI(n.creator.image) : n.creator.image;
-    }
-    else if (Config.User.Image && (creatorIRI == Config.User.IRI || Config.User.SameAs.includes(creatorIRI))) {
-      img = (n.mode == 'read') ? getProxyableIRI(Config.User.Image) : Config.User.Image;
-    }
-    else {
-      img = (Config.User.Contacts && Config.User.Contacts[creatorIRI] && Config.User.Contacts[creatorIRI].Image) ? Config.User.Contacts[creatorIRI].Image : img;
-    }
-    creatorImage = '<img alt="" height="48" rel="schema:image" src="' + img + '" width="48" /> ';
-
-    creatorURLNameIRI = ('url' in n.creator) ? '<a href="' + n.creator.url + '" rel="schema:url">' + creatorNameIRI + '</a>' : '<a href="' + creatorIRI + '">' + creatorNameIRI + '</a>';
-
-    creator = '<span about="' + creatorIRI + '" typeof="schema:Person">' + creatorImage + creatorURLNameIRI + '</span>';
-
-    authors = '<dl class="author-name"><dt>Authors</dt><dd><span rel="dcterms:creator">' + creator + '</span></dd></dl>';
   }
 
-  heading = '<h' + hX + ' property="schema:name">' + creatorName + ' <span rel="oa:motivatedBy" resource="' + motivatedByIRI + '">' + motivatedByLabel + '</span></h' + hX + '>';
-
-  if ('inbox' in n && typeof n.inbox !== 'undefined') {
-    inbox = '<dl class="inbox"><dt>Notifications Inbox</dt><dd><a href="' + n.inbox + '" rel="ldp:inbox">' + n.inbox + '</a></dd></dl>';
-  }
-
-  if ('datetime' in n && typeof n.datetime !== 'undefined') {
-    var time = '<time datetime="' + n.datetime + '" datatype="xsd:dateTime" property="dcterms:created" content="' + n.datetime + '">' + n.datetime.substr(0, 19).replace('T', ' ') + '</time>';
-    var timeLinked = ('iri' in n) ? '<a href="' + n.iri + '">' + time + '</a>' : time;
-    created = '<dl class="created"><dt>Created</dt><dd>' + timeLinked + '</dd></dl>';
-  }
-
-  if (n.language) {
-    language = createLanguageHTML(n.language, { property: 'dcterms:language', label: 'Language' });
-    lang = ' lang="' + n.language + '"';
-    xmlLang = ' xml:lang="' + n.language + '"';
-  }
-  if (n.license) {
-    license = createLicenseHTML(n.license, { rel: 'schema:license', label: 'License' });
-  }
-  if (n.rights) {
-    rights = createRightsHTML(n.rights, { rel: 'dcterms:rights', label: 'Rights' });
-  }
-
-  //TODO: Differentiate language, license, rights on Annotation from Body
-  switch (n.type) {
-    case 'comment': case 'note': case 'bookmark': case 'approve': case 'disapprove': case 'specificity':
-      if (typeof n.target !== 'undefined' || typeof n.inReplyTo !== 'undefined') { //note, annotation, reply
-        //FIXME: Could resourceIRI be a fragment URI or *make sure* it is the document URL without the fragment?
-        //TODO: Use n.target.iri?
-        // console.log(n)
-        if (typeof n.body !== 'undefined') {
-          var tagsArray = [];
-
-          n.body = Array.isArray(n.body) ? n.body : [n.body];
-          n.body.forEach(bodyItem => {
-            var bodyLanguage = createLanguageHTML(bodyItem.language, { property: 'dcterms:language', label: 'Language' }) || language;
-            var bodyLicense = createLicenseHTML(bodyItem.license, { rel: 'schema:license', label: 'License' }) || license;
-            var bodyRights = createRightsHTML(bodyItem.rights, { rel: 'dcterms:rights', label: 'Rights' }) || rights;
-            var bodyValue = bodyItem.value || bodyAltLabel;
-            // var bodyValue = bodyItem.value || '';
-            // var bodyFormat = bodyItem.format ? bodyItem.format : 'rdf:HTML';
-
-            if (bodyItem.purpose) {
-              if (bodyItem.purpose == "describing" || bodyItem.purpose == ns.oa.describing.value) {
-                body += '<section id="note-' + n.id + '" rel="oa:hasBody" resource="#note-' + n.id + '"><h' + (hX + 1) + ' property="schema:name" rel="oa:hasPurpose" resource="oa:describing">Note</h' + (hX + 1) + '>' + bodyLanguage + bodyLicense + bodyRights + '<div datatype="rdf:HTML"' + lang + ' property="rdf:value schema:description" resource="#note-' + n.id + '" typeof="oa:TextualBody"' + xmlLang + '>' + bodyValue + '</div></section>';
-              }
-              if (bodyItem.purpose == "tagging" || bodyItem.purpose == ns.oa.tagging.value) {
-                tagsArray.push(bodyValue);
-              }
-            }
-            else {
-              body += '<section id="note-' + n.id + '" rel="oa:hasBody" resource="#note-' + n.id + '"><h' + (hX + 1) + ' property="schema:name">Note</h' + (hX + 1) + '>' + bodyLanguage + bodyLicense + bodyRights + '<div datatype="rdf:HTML"' + lang + ' property="rdf:value schema:description" resource="#note-' + n.id + '" typeof="oa:TextualBody"' + xmlLang + '>' + bodyValue + '</div></section>';
-            }
-          });
-
-          if (tagsArray.length) {
-            tagsArray = tagsArray
-              .map(tag => htmlEncode(tag.trim()))
-              .filter(tag => tag.length);
-            tagsArray = uniqueArray(tagsArray.sort());
-
-            var tags = tagsArray.map(tag => '<li about="#tag-' + n.id + '-' + generateAttributeId(null, tag) + '" typeof="oa:TextualBody" property="rdf:value" rel="oa:hasPurpose" resource="oa:tagging">' + tag + '</li>').join('');
-
-            body += '<dl id="tags-' + n.id + '" class="tags"><dt>Tags</dt><dd><ul rel="oa:hasBody">' + tags + '</ul></dd></dl>';
-          }
-        }
-        else if (n.bodyValue !== 'undefined') {
-          body += '<p property="oa:bodyValue">' + n.bodyValue + '</p>';
-        }
-        // console.log(body)
-        var targetIRI = '';
-        var targetRelation = 'oa:hasTarget';
-        if (typeof n.target !== 'undefined' && 'iri' in n.target) {
-          targetIRI = n.target.iri;
-          var targetIRIFragment = getFragmentFromString(n.target.iri);
-          //TODO: Handle when there is no fragment
-          //TODO: Languages should be whatever is target's (not necessarily 'en')
-          if (typeof n.target.selector !== 'undefined') {
-            var selectionLanguage = ('language' in n.target.selector && n.target.selector.language) ? n.target.selector.language : '';
-
-            annotationTextSelector = '<div rel="oa:hasSelector" resource="#fragment-selector" typeof="oa:FragmentSelector"><dl class="conformsto"><dt>Fragment selector conforms to</dt><dd><a content="' + targetIRIFragment + '" lang="" property="rdf:value" rel="dcterms:conformsTo" href="https://tools.ietf.org/html/rfc3987" xml:lang="">RFC 3987</a></dd></dl><dl rel="oa:refinedBy" resource="#text-quote-selector" typeof="oa:TextQuoteSelector"><dt>Refined by</dt><dd><span lang="' + selectionLanguage + '" property="oa:prefix" xml:lang="' + selectionLanguage + '">' + n.target.selector.prefix + '</span><mark lang="' + selectionLanguage + '" property="oa:exact" xml:lang="' + selectionLanguage + '">' + n.target.selector.exact + '</mark><span lang="' + selectionLanguage + '" property="oa:suffix" xml:lang="' + selectionLanguage + '">' + n.target.selector.suffix + '</span></dd></dl></div>';
-          }
-        }
-        else if (typeof n.inReplyTo !== 'undefined' && 'iri' in n.inReplyTo) {
-          targetIRI = n.inReplyTo.iri;
-          targetRelation = ('rel' in n.inReplyTo) ? n.inReplyTo.rel : 'as:inReplyTo';
-          // TODO: pass document title and maybe author so they can be displayed on the reply too.
-        }
-
-        hasTarget = '<a href="' + targetIRI + '" rel="' + targetRelation + '">' + targetLabel + '</a>';
-        if (typeof n.target !== 'undefined' && typeof n.target.source !== 'undefined') {
-          hasTarget += ' (<a about="' + n.target.iri + '" href="' + n.target.source + '" rel="oa:hasSource" typeof="oa:SpecificResource">part of</a>)';
-        }
-
-        var targetLanguage = (typeof n.target !== 'undefined' && 'language' in n.target && n.target.language.length) ? '<dl><dt>Language</dt><dd><span lang="" property="dcterms:language" xml:lang="">' + n.target.language + '</span></dd></dl>' : '';
-
-        target = '<dl class="target"><dt>' + hasTarget + '</dt>';
-        if (typeof n.target !== 'undefined' && typeof n.target.selector !== 'undefined') {
-          target += '<dd><blockquote about="' + targetIRI + '" cite="' + targetIRI + '">' + targetLanguage + annotationTextSelector + '</blockquote></dd>';
-        }
-        target += '</dl>';
-
-        target += '<dl class="renderedvia"><dt>Rendered via</dt><dd><a about="' + targetIRI + '" href="https://dokie.li/#i" rel="oa:renderedVia">dokieli</a></dd></dl>';
-
-        var canonical = '<dl class="canonical"><dt>Canonical</dt><dd rel="oa:canonical" resource="' + canonicalId + '">' + canonicalId + '</dd></dl>';
-
-        note = '<article about="' + aAbout + '" id="' + n.id + '" typeof="oa:Annotation' + noteType + '"' + aPrefix + '>' + buttonDelete + '\n\
-' + heading + '\n\
-' + authors + '\n\
-' + created + '\n\
-' + language + '\n\
-' + license + '\n\
-' + rights + '\n\
-' + inbox + '\n\
-' + canonical + '\n\
-' + target + '\n\
-' + body + '\n\
-</article>';
-      }
-      break;
-
-    case 'ref-footnote':
-      var citationURL = (typeof n.citationURL !== 'undefined' && n.citationURL != '') ? '<a href="' + n.citationURL + '" rel="rdfs:seeAlso">' + n.citationURL + '</a>' : '';
-      var bodyValue = (n.body && n.body.length) ? n.body[0].value : '';
-      body = (bodyValue) ? ((citationURL) ? ', ' + bodyValue : bodyValue) : '';
-
-      note = '\n\
-<dl about="#' + n.id + '" id="' + n.id + '" typeof="oa:Annotation">\n\
-<dt><a href="#' + n.refId + '" rel="oa:hasTarget">' + n.refLabel + '</a><span rel="oa:motivation" resource="' + motivatedByIRI + '"></span></dt>\n\
-<dd rel="oa:hasBody" resource="#n-' + n.id + '"><div datatype="rdf:HTML" property="rdf:value" resource="#n-' + n.id + '" typeof="oa:TextualBody">' + citationURL + body + '</div></dd>\n\
-</dl>\n\
-';
-      break;
-
-    case 'ref-citation':
-      heading = '<h' + hX + '>Citation</h' + hX + '>';
-
-      var citingEntityLabel = ('citingEntityLabel' in n.citation) ? n.citation.citingEntityLabel : n.citation.citingEntity;
-      var citationCharacterizationLabel = Config.Citation[n.citation.citationCharacterization] || n.citation.citationCharacterization;
-      var citedEntityLabel = ('citedEntityLabel' in n.citation) ? n.citation.citedEntityLabel : n.citation.citedEntity;
-
-      var citation = '\n\
-<dl about="' + n.citation.citingEntity + '">\n\
-<dt>Cited by</dt><dd><a href="' + n.citation.citingEntity + '">' + citingEntityLabel + '</a></dd>\n\
-<dt>Citation type</dt><dd><a href="' + n.citation.citationCharacterization + '">' + citationCharacterizationLabel + '</a></dd>\n\
-<dt>Cites</dt><dd><a href="' + n.citation.citedEntity + '" rel="' + n.citation.citationCharacterization + '">' + citedEntityLabel + '</a></dd>\n\
-</dl>\n\
-';
-
-      note = '<article about="' + aAbout + '" id="' + n.id + '" prefixes="cito: http://purl.org/spart/cito/">\n\
-' + heading + '\n\
-' + citation + '\n\
-</article>';
-      break;
-
-    default:
-      console.log(`XXX: noteData ${n} with "${n.type}" type not implemented yet`);
-      break;
+  if (mode === 'read' && n.creator && n.creator.iri === Config.User.IRI) {
+    const buttonDelete = '<button aria-label="Delete item" class="delete do" title="Delete item" type="button">' + Icon['.fas.fa-trash-alt'] + '</button>';
+    note = note.replace('>', '>' + buttonDelete);
   }
 
   return note;
 }
 
-export function tagsToBodyObjects(string) {
-  var bodyObjects = [];
+// Localized section labels for the rendered annotation. dokieli only maintains
+// translations for these label slots; every other label (motivation verbs,
+// selector/citation labels, etc.) falls back to the library's English defaults,
+// matching the prior hardcoded output. English defaultValue keeps missing
+// translations from leaking key strings.
+function getAnnotationLabels() {
+  return {
+    language: i18n.t('language.label.textContent', { defaultValue: 'Language' }),
+    license: i18n.t('license.label.textContent', { defaultValue: 'License' }),
+    rights: i18n.t('rights.label.textContent', { defaultValue: 'Rights' }),
+    tags: i18n.t('tags.label.textContent', { defaultValue: 'Tags' }),
+  };
+}
 
-  let tagsArray = string
-    .split(',')
-    .map(tag => htmlEncode(tag.trim()))
-    .filter(tag => tag.length);
+// RDFa subject for the annotation <article>. Read mode points at the stored IRI;
+// otherwise object-addressed motivations (and citations) only carry a fragment
+// subject when serialized as an ActivityStreams object, matching prior behavior.
+function getAnnotationAbout(n, mode) {
+  if (mode === 'read' && n.iri) return n.iri;
+  const objectAbout = n.type === 'ref-citation' ||
+    OBJECT_ABOUT_MOTIVATIONS.has(getPrefixedNameFromIRI(n.motivatedBy || ''));
+  if (objectAbout) return mode === 'object' ? '#' + n.id : '';
+  return '#' + n.id;
+}
 
-  tagsArray = uniqueArray(tagsArray.sort());
-
-  tagsArray.forEach(tag => {
-    bodyObjects.push({
-      "purpose": "tagging",
-      "value": tag
-    })
-  })
-
-  return bodyObjects;
+// Picks the creator avatar following dokieli's resolution order, proxying it in
+// read mode. Returns undefined to let the serializer fall back to its default.
+function resolveAnnotationAvatar(creator, mode) {
+  let img;
+  if (creator.image) {
+    img = creator.image;
+  } else if (Config.User.Image && (creator.iri === Config.User.IRI || (Config.User.SameAs && Config.User.SameAs.includes(creator.iri)))) {
+    img = Config.User.Image;
+  } else if (Config.User.Contacts && Config.User.Contacts[creator.iri] && Config.User.Contacts[creator.iri].Image) {
+    img = Config.User.Contacts[creator.iri].Image;
+  }
+  if (!img) return undefined;
+  return mode === 'read' ? getProxyableIRI(img) : img;
 }
 
 export function addMessageToLog(message, log, options = {}) {
@@ -2189,7 +1990,7 @@ export function createImmutableResource(url, data, options) {
     normalize: true
   };
 
-  var uuid = generateUUID();
+  var uuid = generateAttributeId();
   var containerIRI = url.substr(0, url.lastIndexOf('/') + 1);
   var immutableURL = containerIRI + uuid;
 
@@ -2303,7 +2104,7 @@ export function createMutableResource(url, data, options) {
   //TODO: Should this options include `datetime: new Date()` similar to createImmutableResource?
   setDate(document, { 'id': 'document-created', 'property': 'schema:dateCreated' });
 
-  var uuid = generateUUID();
+  var uuid = generateAttributeId();
   var containerIRI = url.substr(0, url.lastIndexOf('/') + 1);
   var mutableURL = containerIRI + uuid;
 
@@ -2908,41 +2709,69 @@ export function getAnnotationInboxLocationHTML(action) {
   return s;
 }
 
-export function getAnnotationLocationHTML(action) {
-  var s = '', inputs = [], checked = '';
+// Container the annotation would POST to when routed through the user's TypeIndex,
+// resolved for the given action's activity type. Checks the private TypeIndex first
+// (registerAnnotationInTypeIndex prefers it), then public. Returns undefined when no
+// matching registration with an instanceContainer exists.
+export function getRegisteredAnnotationContainer(action) {
+  const typeIndex = Config.User.TypeIndex;
+  const activityIndex = Config.ActionActivityIndex[action];
+  if (!typeIndex || !activityIndex) return undefined;
 
-  if (Config.Editor.mode == 'author') {
-    return s;
-  }
+  const registries = [
+    typeIndex[ns.solid.privateTypeIndex.value],
+    typeIndex[ns.solid.publicTypeIndex.value]
+  ];
 
-  if (typeof Config.AnnotationService !== 'undefined') {
-    if (Config.User.Storage && Config.User.Storage.length > 0 || Config.User.Outbox && Config.User.Outbox.length > 0) {
-      if (Config.User.UI && Config.User.UI['annotationLocationService'] && Config.User.UI.annotationLocationService['checked']) {
-        checked = ' checked="checked"';
+  for (const registrations of registries) {
+    if (!registrations) continue;
+    for (const ti of Object.values(registrations)) {
+      const forClass = ti[ns.solid.forClass.value];
+      const instanceContainer = ti[ns.solid.instanceContainer.value];
+      if (instanceContainer && activityIndex.includes(forClass)) {
+        return instanceContainer;
       }
     }
-    else {
-      checked = ' checked="checked" disabled="disabled"';
-    }
+  }
+  return undefined;
+}
 
-    inputs.push(`<input type="checkbox" id="${action}-annotation-location-service" name="${action}-annotation-location-service"${checked} /><label data-i18n="annotation-location.annotation-service.label" for="${action}-annotation-location-service">${i18n.t('annotation-location.annotation-service.label.textContent')}</label>`);
+export function getAnnotationLocationHTML(action) {
+  var inputs = [];
+
+  if (Config.Editor.mode == 'author') {
+    return '';
   }
 
-  checked = ' checked="checked"';
+  const ui = Config.User.UI || {};
 
-  if (Config.User.Storage && Config.User.Storage.length > 0 || Config.User.Outbox && Config.User.Outbox.length > 0) {
-    if (Config.User.UI && Config.User.UI['annotationLocationPersonalStorage'] && !Config.User.UI.annotationLocationPersonalStorage['checked']) {
-      checked = '';
-    }
+  // Show the container URL the annotation will POST to next to each label.
+  const targetHTML = (url) => url ? ` <code>${htmlEncode(url)}</code>` : '';
 
-    inputs.push(`<input type="checkbox" id="${action}-annotation-location-personal-storage" name="${action}-annotation-location-personal-storage"${checked} /><label data-i18n="annotation-location.personal-storage.label" for="${action}-annotation-location-personal-storage">${i18n.t('annotation-location.personal-storage.label.textContent')}</label>`);
-  }
+  // Nothing is checked by default; only a remembered choice (UI state) pre-checks.
+  // Labels come from the translation strings keyed by i18n.
+  const options = [
+    { suffix: 'annotation-service', uiKey: 'annotationLocationService', url: (typeof Config.AnnotationService !== 'undefined') ? Config.AnnotationService : undefined },
+    { suffix: 'annotation-store', uiKey: 'annotationLocationAnnotationStore', url: getRegisteredAnnotationContainer(action) },
+    { suffix: 'personal-storage', uiKey: 'annotationLocationPersonalStorage', url: (Config.User.Storage && Config.User.Storage.length > 0) ? Config.User.Storage[0] : undefined },
+    { suffix: 'activity-outbox', uiKey: 'annotationLocationActivityOutbox', url: (Config.User.Outbox && Config.User.Outbox.length > 0) ? Config.User.Outbox[0] : undefined },
+  ];
+
+  options.forEach(({ suffix, uiKey, url }) => {
+    if (!url) return;
+    const id = `${action}-annotation-location-${suffix}`;
+    const labelI18n = `annotation-location.${suffix}.label`;
+    const checked = (ui[uiKey] && ui[uiKey].checked) ? ' checked="checked"' : '';
+    inputs.push(`<li><input type="checkbox" id="${id}" name="${id}"${checked} /><label data-i18n="${labelI18n}" for="${id}">${i18n.t(labelI18n + '.textContent')}</label>${targetHTML(url)}</li>`);
+  });
+
+  let annotationInputs = `<p>${i18n.t('annotation-location-selection.not-found.p.textContent')}</p>`;
 
   if (inputs.length) {
-    s = `<span data-i18n="annotation-location-selection.store-at.span">${i18n.t('annotation-location-selection.store-at.span.textContent')}</span>` + inputs.join('');
+    annotationInputs = `<ul>${inputs.join('')}</ul>`;
   }
 
-  return s;
+  return `<details class="annotation-location-details" open=""><summary data-i18n="annotation-location-selection.store-at.span">${i18n.t('annotation-location-selection.store-at.span.textContent')}</summary>${annotationInputs}</details>`;
 }
 
 export function getPublicationStatusOptionsHTML(options) {
@@ -3273,18 +3102,33 @@ export function serializeTableSectionToText(section) {
 export function focusNote() {
   document.addEventListener('click', e => {
     var ref = e.target.closest('span.ref.do sup a');
+    if (!ref) return;
 
-    if (ref) {
-      var hash = new URL(ref.href).hash;
-      var refId = hash.substring(1);
-      var aside = document.querySelector('#document-notifications[class~="do"]:has(article[id="' + refId + '"])');
+    var hash = new URL(ref.href).hash;
+    if (!hash.length) return;
+    var refId = hash.substring(1);
 
-      if (!hash.length || !aside) return;
+    var aside = document.getElementById('document-notifications');
+    if (!aside) return;
 
-      if (!aside.classList.contains("on")) {
-        aside.classList.add('on');
-        window.history.replaceState({}, null, hash);
-      }
+    e.preventDefault();
+
+    if (!aside.classList.contains('on')) {
+      aside.classList.add('on');
+    }
+    window.history.replaceState({}, null, hash);
+
+    var revealNote = () => {
+      var note = aside.querySelector('[id="' + refId + '"]');
+      if (note) note.scrollIntoView();
+      return !!note;
+    };
+
+    // The note may be lazily added to the panel after it opens; observe briefly.
+    if (!revealNote()) {
+      var obs = new MutationObserver(() => { if (revealNote()) obs.disconnect(); });
+      obs.observe(aside, { childList: true, subtree: true });
+      setTimeout(() => obs.disconnect(), 5000);
     }
   });
 }
@@ -3615,7 +3459,7 @@ export function addCitation(citation, s) {
   // console.log("  " + citationCharacterization + "  " + citedEntity);
   var citationCharacterizationLabel = Config.Citation[citationCharacterization] || citationCharacterization;
 
-  var id = generateUUID(citingEntity);
+  var id = generateAttributeId(citingEntity);
   var refId;
 
   var cEURL = stripFragmentFromString(citingEntity);
@@ -4656,7 +4500,7 @@ export function getCitation(i, options) {
               data = JSON.parse(data);
               // console.log(data)
 
-              var authorURL = 'http://example.com/.well-known/genid/' + generateUUID();
+              var authorURL = 'http://example.com/.well-known/genid/' + generateAttributeId();
               if (data.links && Array.isArray(data.links) && data.links.length) {
                 // console.log(data.links[0].url)
                 authorURL = data.links[0].url;
@@ -4827,6 +4671,8 @@ export function getCitationHTML(citationGraph, citationURI, options) {
 
   var citationReason = (options.citationRelation && Config.Citation[options.citationRelation]) ? `, Citation Reason: ${Config.Citation[options.citationRelation]}` : '';
 
+  var anchorTitle = Config.Citation[options.citationRelation] ? ` title="${Config.Citation[options.citationRelation]}"` : '';
+
   var citationIdLabel = citationURI;
   var prefixCitationLink = '';
 
@@ -4843,7 +4689,7 @@ export function getCitationHTML(citationGraph, citationURI, options) {
     citationIdLabel = citationURI;
   }
 
-  var citationHTML = authors + title + datePublished + content + prefixCitationLink + '<a about="#' + options.refId + '"' + dataVersionDate + dataVersionURL + ' href="' + citationURI + '" rel="schema:citation ' + options.citationRelation  + '" title="' + Config.Citation[options.citationRelation] + '">' + citationIdLabel + '</a> [' + dateAccessed + citationReason + ']';
+  var citationHTML = authors + title + datePublished + content + prefixCitationLink + '<a about="#' + options.refId + '"' + dataVersionDate + dataVersionURL + ' href="' + citationURI + '" rel="schema:citation ' + options.citationRelation  + '"' + anchorTitle + '>' + citationIdLabel + '</a> [' + dateAccessed + citationReason + ']';
   //console.log(citationHTML);
   return citationHTML;
 }

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -47,7 +47,7 @@ import { WebsocketProvider } from 'y-websocket'
 import { IndexeddbPersistence } from 'y-indexeddb'
 import { ySyncPlugin, yCursorPlugin, yUndoPlugin, undo, redo, initProseMirrorDoc, prosemirrorToYDoc } from 'y-prosemirror'
 import { currentLocation } from "../uri.js";
-import { getRandomIndex, stringToColor, generateUUID } from "../util.js";
+import { getRandomIndex, stringToColor } from "../util.js";
 import { defaultContentHTML } from "../cv.js";
 import { cvNavDecorationPlugin } from "./plugins/cvNavDecorations.js";
 import { protectPlaceholdersPlugin } from "./plugins/protectPlaceholders.js";
@@ -357,11 +357,6 @@ export class Editor {
   }
 
 
-  importTextQuoteSelector(containerNode, selector, refId, motivatedBy, docRefType, options) {
-    const toolbarView = this.authorToolbarView || this.socialToolbarView;
-    return toolbarView?.importTextQuoteSelector(containerNode, selector, refId, motivatedBy, docRefType, options)
-  }
-
   showTextQuoteSelectorFromLocation() {
     const toolbarView = this.authorToolbarView || this.socialToolbarView;
     return toolbarView?.showTextQuoteSelectorFromLocation();
@@ -384,6 +379,12 @@ export class Editor {
     // console.log('toolbar',toolbarView)
     // console.log(toolbarView?.replaceSelectionWithFragment)
     return toolbarView?.replaceSelectionWithNodeFromFragment(fragment)
+  }
+
+  // Inserts an inline fragment while keeping wrapper nodes (e.g. <span class="ref">) closed.
+  replaceSelectionWithInlineFragment(fragment){
+    const toolbarView = this.authorToolbarView || this.socialToolbarView;
+    return toolbarView?.replaceSelectionWithInlineFragment(fragment)
   }
 
 

--- a/src/editor/toolbar/author/author.js
+++ b/src/editor/toolbar/author/author.js
@@ -17,7 +17,7 @@ limitations under the License.
 
 import { toggleMark, setBlockType } from "prosemirror-commands"
 import { wrapInList, liftListItem } from "prosemirror-schema-list"
-import { DOMSerializer, DOMParser } from "prosemirror-model"
+import { DOMSerializer, DOMParser, Slice } from "prosemirror-model"
 import { TextSelection, NodeSelection } from "prosemirror-state"
 import { schema, allowedEmptyAttributes } from "./../../schema/base.js"
 import { formHandlerLanguage, formHandlerA, formHandlerAnnotate, formHandlerBlockquote, formHandlerImg, formHandlerQ, formHandlerCitation, formHandlerRequirement, formHandlerSemantics } from "./handlers.js"
@@ -635,6 +635,16 @@ nodeToHTML(node, schema) {
     let tr = state.tr.replaceSelectionWith(node);
     // console.log(tr)
     dispatch(tr);
+  }
+
+  // Like replaceSelectionWithFragment, but inserts the fragment as a closed slice so
+  // wrapper nodes survive. parseSlice returns an open slice, which flattens a single
+  // inline wrapper (e.g. the <span class="ref"> around a note/citation mark + sup)
+  // into the surrounding paragraph.
+  replaceSelectionWithInlineFragment(fragment) {
+    const { state, dispatch } = this.editorView;
+    const slice = DOMParser.fromSchema(state.schema).parseSlice(fragment);
+    dispatch(state.tr.replaceSelection(new Slice(slice.content, 0, 0)));
   }
 
   //Equivalent to insertAdjacentHTML('beforend') / appendChild?
@@ -1724,33 +1734,19 @@ async function getImageDimensions(blobUrl) {
 }
 
 //XXX: I don't know what to do with this thing yet - VB
-// I think this should actually be getClosestSectionNodeEndPos and return parentPos + parentNode.nodeSize (which is the position where the fragment should be inserted to resemble `beforeend`)
+// Position just after the selection's nearest section/container ancestor (resembles `beforeend`).
+// Walks ancestor depths so it never calls ResolvedPos.before() at the top level (which throws).
 function getClosestSectionNodeEndPos(view) {
-  const { from } = view.state.selection;
-  const nodePos = view.state.doc.resolve(from);
+  const $pos = view.state.doc.resolve(view.state.selection.from);
 
-  function findClosestAncestor(pos) {
-    let parentPos = pos.before();
-    let parentNode = view.state.doc.nodeAt(parentPos);
-
-    while (parentNode) {
-      // console.log("parentNode", parentNode)
-
-      var parentNodeName = parentNode.type.name.toLowerCase();
-
-      if (parentNodeName === 'section') {
-        return parentPos + parentNode.nodeSize;
-      }
-      else if (['div', 'article', 'main', 'body'].includes(parentNodeName)) {
-        return parentPos + parentNode.nodeSize;
-      }
-
-      parentPos = view.state.doc.resolve(parentPos).before();
-      parentNode = view.state.doc.nodeAt(parentPos);
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const node = $pos.node(depth);
+    const name = node.type.name.toLowerCase();
+    if (name === 'section' || ['div', 'article', 'main', 'body'].includes(name)) {
+      return $pos.before(depth) + node.nodeSize;
     }
-
-    return null;
   }
 
-  return findClosestAncestor(nodePos); 
+  // No container ancestor (e.g. selection resolves at the top level): append at document end.
+  return view.state.doc.content.size;
 }

--- a/src/editor/toolbar/social/handlers.js
+++ b/src/editor/toolbar/social/handlers.js
@@ -18,10 +18,10 @@ limitations under the License.
 import { getSelectedParentElement, restoreSelection, getInboxOfClosestNodeWithSelector, createNoteData} from "../../utils/annotation.js";
 import { generateAttributeId, getDateTimeISO } from "../../../util.js"
 import { getNodeLanguage, getFormValues, createHTML } from "../../../utils/html.js";
-import { getReferenceLabel, createActivityHTML, createNoteDataHTML, } from "../../../doc.js";
+import { getReferenceLabel, createActivityHTML, createNoteDataHTML, getRegisteredAnnotationContainer } from "../../../doc.js";
 import { getAbsoluteIRI, stripFragmentFromString } from "../../../uri.js"
 import Config from "../../../config.js"
-import { notifyInbox, postActivity, showActivities, registerAnnotationInTypeIndex } from "../../../activity.js"
+import { notifyInbox, postActivity, showActivities, registerAnnotationInTypeIndex, markAnnotationTarget } from "../../../activity.js"
 import { shareResource } from "../../../dialog.js";
 import { domSanitize } from "../../../utils/sanitization.js";
 
@@ -86,10 +86,12 @@ export function formHandlerAnnotate(e, action) {
   };
 
   const annotationInboxLocation = formValues[`${action}-annotation-inbox`];
+  const annotationLocationAnnotationStore = formValues[`${action}-annotation-location-annotation-store`];
   const annotationLocationPersonalStorage = formValues[`${action}-annotation-location-personal-storage`];
-  const annotationLocationService = formValues[`${action}-annotation-location-service`];
+  const annotationLocationActivityOutbox = formValues[`${action}-annotation-location-activity-outbox`];
+  const annotationLocationService = formValues[`${action}-annotation-location-annotation-service`];
 
-  updateUserUI({ annotationInboxLocation, annotationLocationPersonalStorage, annotationLocationService }, formValues)
+  updateUserUI({ annotationInboxLocation, annotationLocationAnnotationStore, annotationLocationPersonalStorage, annotationLocationActivityOutbox, annotationLocationService })
 
   processAction(action, formValues, selectionData);
 
@@ -97,14 +99,9 @@ export function formHandlerAnnotate(e, action) {
 }
 
 
-function updateUserUI(fields, formValues) {
+function updateUserUI(fields) {
   Object.entries(fields).forEach(([key, value]) => {
-    const input = formValues[key];
-    Config.User.UI[key] = { checked: false };
-  
-    if (input) {
-      Config.User.UI[key].checked = input.checked;
-    }
+    Config.User.UI[key] = { checked: Boolean(value) };
   });
 }
 
@@ -113,6 +110,13 @@ export function processAction(action, formValues, selectionData) {
   //TODO:
 
   const data = getFormActionData(action, formValues, selectionData);
+
+  // Sanitize the user-supplied note body here, at the boundary. The generated
+  // annotation markup (lib RDFa + createHTML wrapper) is trusted and is NOT
+  // sanitized as a whole - only this user input is.
+  if (data.formData && typeof data.formData.content === 'string') {
+    data.formData.content = domSanitize(data.formData.content);
+  }
 
   const { annotationDistribution, ...otherFormData } = data;
 
@@ -130,7 +134,13 @@ export function processAction(action, formValues, selectionData) {
 
         var noteData = createNoteData(annotation);
 
-        annotation['motivatedByIRI'] = noteData['motivatedByIRI'];
+        // POST with a relative @id ('') so the stored annotation is addressed by its
+        // storage URL (the server resolves '' against it), not the urn:uuid. The urn
+        // stays as oa:canonical. This matches dokieli's long-standing RDFa form and
+        // keeps the mark/panel/delete references (all URL-based) consistent.
+        noteData.iri = '';
+
+        annotation['motivatedBy'] = noteData['motivatedBy'];
 
         if ('profile' in annotation && annotation.profile == 'https://www.w3.org/ns/activitystreams') {
           var notificationData = createActivityData(annotation, { 'relativeObject': true });
@@ -147,7 +157,10 @@ export function processAction(action, formValues, selectionData) {
         // console.log(data)
         // console.log(annotation)
 
-        postActivity(annotation['containerIRI'], annotation.id, noteHTML, annotation)
+        // Carry the structured annotation (noteData) so postActivity can
+        // serialize JSON-LD directly from it via @dokieli/web-annotation when the
+        // server prefers JSON-LD (instead of the RDFa → graph round-trip).
+        postActivity(annotation['containerIRI'], annotation.id, noteHTML, { ...annotation, annotationObject: noteData })
           .catch(error => {
             // console.log('Error serializing annotation:', error)
             // console.log(error)
@@ -164,6 +177,13 @@ export function processAction(action, formValues, selectionData) {
 
             if (annotation.canonical) {
               registerAnnotationInTypeIndex(annotation['containerIRI'], ns.oa.Annotation.value);
+
+              // Mark the passage now, from the in-memory selector - the re-fetch path
+              // (positionActivity -> showActivities) 429s under load, so the highlight
+              // must not depend on it. Idempotent against the re-fetch path. Uses the
+              // library-decided selector (RangeSelector for cross-node selections) so the
+              // highlight spans multiple nodes/sections, not just a single TextQuote match.
+              markAnnotationTarget(annotation['noteIRI'], noteData.target?.selector || annotation.selectionData?.selector, { motivatedBy: annotation.motivatedBy, id: annotation.id });
             }
 
             // console.log(annotation, data.options)
@@ -314,8 +334,10 @@ export function getAnnotationDistribution(action, data) {
   //This annotationInbox is about when the selected text is part of an existing Annotation, it gets that Annotation's own inbox which is used towards announcing the annotation that's about to be created. (This is not related to whether an inbox should be assigned to an annotation that's about to be created.)
   const annotationInbox =  getInboxOfClosestNodeWithSelector(selectedParentElement, '.do[typeof="oa:Annotation"]');
   //These are whether the user wants to send a copy of their annotation to a personal storage and/or to an annotation service.
-  const annotationLocationPersonalStorage = formData[`${action}-annotation-location-personal-storage`];
-  const annotationLocationService = formData[`${action}-annotation-location-service`];
+  const annotationLocationAnnotationStore = formData['annotation-location-annotation-store'];
+  const annotationLocationPersonalStorage = formData['annotation-location-personal-storage'];
+  const annotationLocationOutbox = formData['annotation-location-activity-outbox'];
+  const annotationLocationService = formData['annotation-location-annotation-service'];
 
   //Use if (activityIndex) when all action values are taken into account e.g., `note` in author mode
 
@@ -326,52 +348,30 @@ export function getAnnotationDistribution(action, data) {
   const activityIndex = Config.ActionActivityIndex[action];
 
   //XXX: Use TypeIndex location as canonical if available, otherwise storage. Note how noteIRI is treated later
-  if ((annotationLocationPersonalStorage && Config.User.TypeIndex) || (!annotationLocationPersonalStorage && !annotationLocationService && Config.User.TypeIndex)) {
-    //TODO: Preferring publicTypeIndex for now. Refactor this when the UI allows user to decide whether to have it public or private.
+  if (annotationLocationAnnotationStore && Config.User.TypeIndex) {
+    // Resolve the registered container from private or public TypeIndex for this action.
+    const registeredContainer = getRegisteredAnnotationContainer(action);
 
-    var publicTypeIndexes = Config.User.TypeIndex[ns.solid.publicTypeIndex.value];
-    var privateTypeIndexes = Config.User.TypeIndex[ns.solid.privateTypeIndex.value];
+    if (registeredContainer) {
+      activityTypeMatched = true;
 
-    if (publicTypeIndexes) {
-      var publicTIValues = Object.values(publicTypeIndexes);
-      // console.log(publicTIValues)
-      publicTIValues.forEach(ti => {
-        //XXX: For now, we are only sending the annotation to one location that's already matched
-        if (activityTypeMatched) return;
+      containerIRI = registeredContainer;
 
-        var forClass = ti[ns.solid.forClass.value];
-        var instanceContainer = ti[ns.solid.instanceContainer.value];
-        var instance = ti[ns.solid.instance.value];
+      fromContentType = 'text/html';
+      // contentType = 'text/html';
+      contentType = fromContentType;
 
-        if (activityIndex?.includes(forClass)) {
-          if (instanceContainer) {
-            activityTypeMatched = true;
+      noteURL = noteIRI = containerIRI + id;
+      contextProfile = {
+        // 'subjectURI': noteIRI,
+      };
+      aLS = { 'id': id, 'containerIRI': containerIRI, 'noteURL': noteURL, 'noteIRI': noteIRI, 'fromContentType': fromContentType, 'contentType': contentType, 'canonical': true, 'annotationInbox': annotationInbox };
 
-            containerIRI = instanceContainer;
-
-            fromContentType = 'text/html';
-            // contentType = 'text/html';
-            contentType = fromContentType;
-
-            noteURL = noteIRI = containerIRI + id;
-            contextProfile = {
-              // 'subjectURI': noteIRI,
-            };
-            aLS = { 'id': id, 'containerIRI': containerIRI, 'noteURL': noteURL, 'noteIRI': noteIRI, 'fromContentType': fromContentType, 'contentType': contentType, 'canonical': true, 'annotationInbox': annotationInbox };
-
-            annotationDistribution.push(aLS);
-          }
-          //TODO: Not handling `instance` yet.
-        }
-      })
-
-    }
-    else if (privateTypeIndexes) {
-
+      annotationDistribution.push(aLS);
     }
   }
 
-  if ((annotationLocationPersonalStorage && Config.User.Outbox) || (!annotationLocationPersonalStorage && !annotationLocationService && Config.User.Outbox)) {
+  if (annotationLocationOutbox && Config.User.Outbox) {
     containerIRI = Config.User.Outbox[0];
 
     fromContentType = 'text/html';
@@ -388,7 +388,8 @@ export function getAnnotationDistribution(action, data) {
       'profile': 'https://www.w3.org/ns/activitystreams'
     };
     aLS = { 'id': id, 'containerIRI': containerIRI, 'noteURL': noteURL, 'noteIRI': noteIRI, 'fromContentType': fromContentType, 'contentType': contentType, 'annotationInbox': annotationInbox };
-    if (typeof Config.User.Storage === 'undefined' && !activityTypeMatched) {
+    // Outbox is canonical only when no registered or personal storage copy is selected.
+    if (!activityTypeMatched && !annotationLocationPersonalStorage) {
       aLS['canonical'] = true;
     }
 
@@ -399,7 +400,7 @@ export function getAnnotationDistribution(action, data) {
     }
   }
 
-  if (!activityTypeMatched && ((annotationLocationPersonalStorage && Config.User.Storage) || (!annotationLocationPersonalStorage && !annotationLocationService && Config.User.Storage))) {
+  if (annotationLocationPersonalStorage && Config.User.Storage) {
     containerIRI = Config.User.Storage[0];
 
     fromContentType = 'text/html';
@@ -410,7 +411,8 @@ export function getAnnotationDistribution(action, data) {
     contextProfile = {
       // 'subjectURI': noteIRI,
     };
-    aLS = { 'id': id, 'containerIRI': containerIRI, 'noteURL': noteURL, 'noteIRI': noteIRI, 'fromContentType': fromContentType, 'contentType': contentType, 'canonical': true, 'annotationInbox': annotationInbox };
+    // The registered (TypeIndex) location, when selected, is the canonical copy.
+    aLS = { 'id': id, 'containerIRI': containerIRI, 'noteURL': noteURL, 'noteIRI': noteIRI, 'fromContentType': fromContentType, 'contentType': contentType, 'canonical': !activityTypeMatched, 'annotationInbox': annotationInbox };
 
     if (!isDuplicateLocation(annotationDistribution, containerIRI)) {
       annotationDistribution.push(aLS);
@@ -425,18 +427,18 @@ export function getAnnotationDistribution(action, data) {
 
     contextProfile = {
       '@context': [
-        'http://www.w3.org/ns/anno.jsonld',
+        'https://www.w3.org/ns/anno.jsonld',
         { 'as': 'https://www.w3.org/ns/activitystreams#', 'schema': 'http://schema.org/' }
       ],
       // 'subjectURI': noteIRI,
-      'profile': 'http://www.w3.org/ns/anno.jsonld'
+      'profile': 'https://www.w3.org/ns/anno.jsonld'
     };
 
-    if (!annotationLocationPersonalStorage && annotationLocationService) {
+    if (!annotationLocationAnnotationStore && !annotationLocationPersonalStorage && !annotationLocationOutbox && annotationLocationService) {
       noteURL = noteIRI = containerIRI + id;
       aLS = { 'id': id, 'containerIRI': containerIRI, 'noteURL': noteURL, 'noteIRI': noteIRI, 'fromContentType': fromContentType, 'contentType': contentType, 'canonical': true,'annotationInbox': annotationInbox };
     }
-    else if (annotationLocationPersonalStorage) {
+    else if (annotationLocationAnnotationStore || annotationLocationPersonalStorage || annotationLocationOutbox) {
       noteURL = containerIRI + id;
       aLS = { 'id': id, 'containerIRI': containerIRI, 'noteURL': noteURL, 'noteIRI': noteIRI, 'fromContentType': fromContentType, 'contentType': contentType, 'annotationInbox': annotationInbox };
     }
@@ -464,7 +466,7 @@ export function createActivityData(annotation, options = {}) {
 
   var notificationStatements = '    <dl about="' + noteIRI + '">\n\
 <dt>Object type</dt><dd><a about="' + noteIRI + '" typeof="oa:Annotation" href="' + ns.oa.Annotation.value + '">Annotation</a></dd>\n\
-<dt>Motivation</dt><dd><a href="' + Config.getPrefixURI(annotation.motivatedByIRI.split(':')[0]) + annotation.motivatedByIRI.split(':')[1] + '" property="oa:motivation">' + annotation.motivatedByIRI.split(':')[1] + '</a></dd>\n\
+<dt>Motivation</dt><dd><a href="' + Config.getPrefixURI(annotation.motivatedBy.split(':')[0]) + annotation.motivatedBy.split(':')[1] + '" property="oa:motivation">' + annotation.motivatedBy.split(':')[1] + '</a></dd>\n\
 </dl>\n\
 ';
 

--- a/src/editor/toolbar/toolbar.js
+++ b/src/editor/toolbar/toolbar.js
@@ -20,8 +20,8 @@ import { NodeSelection } from "prosemirror-state"
 import { Icon } from "../../ui/icons.js"
 import { getButtonHTML, updateButtons } from "../../ui/buttons.js"
 import { getAnnotationInboxLocationHTML, getAnnotationLocationHTML, getClassesOfProductsConcepts, getDocument, getLanguageOptionsHTML, getLicenseOptionsHTML, getReferenceLabel } from "../../doc.js";
-import { getTextQuoteHTML, cloneSelection, setSelection, selectionToTextQuote, setSelectionFromTextQuote, getSelectedParentElement, getTextContentExcludingSups } from "../utils/annotation.js";
-import { escapeRegExp, matchAllIndex } from "../../util.js";
+import { cloneSelection, selectionToTextQuote, setSelectionFromTextQuote, getSelectedParentElement } from "../utils/annotation.js";
+import { applyMarksFromTextQuote } from "@dokieli/web-annotation";
 import { fragmentFromString, getDocumentContentNode, selectArticleNode } from "../../utils/html.js";
 import { showUserIdentityInput } from "../../auth.js";
 import { getLinkRelation } from "../../graph.js";
@@ -234,12 +234,18 @@ export class ToolbarView {
       const margin = 10;
       const toolbarHeight = this.dom.offsetHeight;
       const toolbarWidth = this.dom.offsetWidth;
-      const selection = window.getSelection();
-      const range = selection.getRangeAt(0);
-      const selectionPosition = range.getBoundingClientRect();
 
       toolbarForm.style.left = `${(toolbarWidth / 2) - (toolbarForm.offsetWidth / 2)}px`;
       toolbarForm.style.right = 'initial';
+
+      const selection = window.getSelection();
+      if (!selection || !selection.rangeCount) {
+          toolbarForm.style.top = `${toolbarHeight + margin / 2}px`;
+          return;
+      }
+
+      const range = selection.getRangeAt(0);
+      const selectionPosition = range.getBoundingClientRect();
 
       if ((selectionPosition.top >= toolbarHeight + margin * 2) && (window.innerHeight - selectionPosition.bottom >= toolbarForm.offsetHeight + margin * 2)) {
           toolbarForm.style.top = `${toolbarHeight + selectionPosition.height + margin * 1.5}px`;
@@ -598,15 +604,9 @@ export class ToolbarView {
       }
 
 
-      //TODO: Revisit
-      // const allowMultiNodeSelection = false;
-      // if (allowMultiNodeSelection) {
-      //   return;
-      // }
-
-      if (isSelection && !this.isSelectionsStartEndRangesWithinSameParent(selection)) {
-        return;
-      }
+      // Cross-node selections are supported: the annotation uses a RangeSelector
+      // (XPath start/end refined by TextQuotes) so start and end may be in
+      // different parents. No same-parent restriction here.
 
       if (isSelection) {
         this.selection = cloneSelection();
@@ -729,15 +729,6 @@ export class ToolbarView {
     document.addEventListener("keydown", this.handleEscKey);
   }
 
-  isSelectionsStartEndRangesWithinSameParent(selection) {
-    selection = selection || window.getSelection();
-
-    const startParentNode = selection.getRangeAt(0).startContainer.parentNode;
-    const endParentNode = selection.getRangeAt(selection.rangeCount - 1).endContainer.parentNode;
-
-    return startParentNode === endParentNode; // Returns true if both are the same
-  }
-
   clearToolbarButton(button) {
     const btnNode = this.dom.querySelector(`#${'editor-button-' + button}`);
 
@@ -835,105 +826,8 @@ export class ToolbarView {
   
       var docRefType = '<sup class="ref-highlighting"><a rel="oa:hasTarget" href="#' + refId + '">' + refLabel + '</a></sup>';
   
-      var options = {
-        'do': true,
-        'mode': '#selector'
-      };
-      // console.log(selector)
-      // console.log(refId)
-      this.importTextQuoteSelector(containerNode, selector, refId, motivatedBy, docRefType, options);
+      applyMarksFromTextQuote(containerNode, selector, { 'annotationUrl': '#' + refId, 'id': refId, 'className': 'ref do', 'reference': docRefType, 'excludeMatchesIn': '#document-notifications' });
     }
-  }
-
-  // TODO: refactor this to use replaceSelectionWithFragment
-  importTextQuoteSelector(containerNode, selector, refId, motivatedBy, docRefType, options) {
-    // console.log(containerNode)
-    // console.log(selector)
-    // console.log(refId)
-    // console.log(motivatedBy)
-    // console.log(docRefType)
-    // console.log(options)
-    // Exclude <sup> elements so that annotation labels injected by prior showAnnotation calls don't shift character offsets and break phrase matching for subsequent annotations targeting the same passage.
-    var containerNodeTextContent = getTextContentExcludingSups(containerNode);
-      //XXX: Seems better?
-      // var containerNodeTextContent = fragmentFromString(getDocument(containerNode, documentOptions)).textContent.trim();
-    // console.log(containerNodeTextContent);
-    options = options || {};
-
-    // console.log(selector)
-    var prefix = selector.prefix || '';
-    var exact = selector.exact || '';
-    var suffix = selector.suffix || '';
-
-    var phrase = escapeRegExp(prefix.toString() + exact.toString() + suffix.toString());
-    // console.log(phrase);
-
-    var selectedParentNode;
-
-    var textMatches = matchAllIndex(containerNodeTextContent, new RegExp(phrase, 'g'));
-    // console.log(textMatches)
-
-    textMatches.forEach(item => {
-      // console.log('phrase:')
-      // console.log(phrase)
-      // console.log(item)
-      var selectorIndex = item.index;
-      // console.log('selectorIndex:')
-      // console.log(selectorIndex)
-      // var selectorIndex = containerNodeTextContent.indexOf(prefix + exact + suffix);
-      // console.log(selectorIndex);
-
-      // if (selectorIndex >= 0) {
-      var exactStart = selectorIndex + prefix.length
-      var exactEnd = selectorIndex + prefix.length + exact.length;
-      var selection = { start: exactStart, end: exactEnd };
-      // console.log('selection:')
-      // console.log(selection)
-      var ref = getTextQuoteHTML(refId, motivatedBy, exact, docRefType, options);
-      // console.log('containerNode:')
-      // console.log(containerNode)
-
-      // MediumEditor.selection.importSelection(selection, containerNode, document);
-      setSelection(exactStart, exactEnd, containerNode);
-
-
-      //XXX: Review
-      selection = window.getSelection();
-      var r = selection.getRangeAt(0);
-      selection.removeAllRanges();
-      selection.addRange(r);
-      r.collapse(true);
-
-      // Skip matches that fall inside the notifications panel
-      if (r.commonAncestorContainer.parentNode?.closest('#document-notifications')) {
-        return;
-      }
-
-      // If this text is already wrapped in a span.ref, the same passage already has at least one annotation. Reuse the existing mark and just append the new <sup>.
-      var existingRefSpan = r.commonAncestorContainer.parentNode?.closest('span.ref');
-      if (existingRefSpan) {
-        existingRefSpan.insertAdjacentHTML('beforeend', docRefType);
-        selectedParentNode = existingRefSpan;
-      }
-      else {
-        selectedParentNode = r.commonAncestorContainer.parentNode;
-        var selectedParentNodeValue = r.commonAncestorContainer.nodeValue;
-
-        var selectionUpdated = fragmentFromString(selectedParentNodeValue.substr(0, r.startOffset) + ref + selectedParentNodeValue.substr(r.startOffset + exact.length));
-
-        //XXX: Review. This feels a bit dirty
-        for(var i = 0; i < selectedParentNode.childNodes.length; i++) {
-          var n = selectedParentNode.childNodes[i];
-          if (n.nodeType === 3 && n.nodeValue === selectedParentNodeValue) {
-            selectedParentNode.replaceChild(selectionUpdated, n);
-          }
-        }
-      }
-
-      // console.log('---')
-    })
-
-    return selectedParentNode;
   }
 
   destroy() {
@@ -953,6 +847,9 @@ export class ToolbarView {
 
 // Consider putting this elsewhere or making it part of the class
 export function annotateFormControls(options) {
+  const locationHTML = getAnnotationLocationHTML(options.button);
+  // When location options exist but none are pre-checked, start with submit disabled.
+  const submitDisabled = (locationHTML.includes('type="checkbox"') && !locationHTML.includes('checked="checked"')) ? ' disabled=""' : '';
   return `
     <fieldset>
       <legend data-i18n="editor.toolbar.${options.button}.form.legend">${options.legend}</legend>
@@ -967,19 +864,36 @@ export function annotateFormControls(options) {
       <select class="editor-form-select" id="${options.button}-language" name="${options.button}-language">${getLanguageOptionsHTML()}</select>
       <label data-i18n="license.label" for="${options.button}-license">${i18n.t('license.label.textContent')}</label>
       <select class="editor-form-select" id="${options.button}-license" name="${options.button}-license">${getLicenseOptionsHTML()}</select>
-      <span class="annotation-location-selection">${getAnnotationLocationHTML(options.button)}</span>
+      <span class="annotation-location-selection">${locationHTML}</span>
       <span class="annotation-inbox">${getAnnotationInboxLocationHTML(options.button)}</span>
 
-      <button class="editor-form-submit" data-i18n="editor.toolbar.form.post.button" type="submit">${i18n.t('editor.toolbar.form.post.button.textContent')}</button>
+      <button class="editor-form-submit" data-i18n="editor.toolbar.form.post.button" type="submit"${submitDisabled}>${i18n.t('editor.toolbar.form.post.button.textContent')}</button>
       <button class="editor-form-cancel" data-i18n="editor.toolbar.form.cancel.button" type="button">${i18n.t('editor.toolbar.form.cancel.button.textContent')}</button>
     </fieldset>
   `
+}
+
+// Disable the annotate form's submit while no storage location is checked.
+export function updateAnnotateSubmitState(fieldset) {
+  if (!fieldset) return;
+  const submit = fieldset.querySelector('.editor-form-submit');
+  const checkboxes = fieldset.querySelectorAll('.annotation-location-selection input[type="checkbox"]');
+  if (!submit || !checkboxes.length) return;
+  submit.disabled = !Array.from(checkboxes).some(c => c.checked);
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('change', (e) => {
+    const cb = e.target.closest && e.target.closest('.annotation-location-selection input[type="checkbox"]');
+    if (cb) updateAnnotateSubmitState(cb.closest('fieldset'));
+  });
 }
 
 export function updateAnnotationServiceForm(action) {
   var annotationServices = document.querySelectorAll('.do.editor-toolbar .annotation-location-selection');
   for (var i = 0; i < annotationServices.length; i++) {
     annotationServices[i].replaceChildren(fragmentFromString(getAnnotationLocationHTML(action)));
+    updateAnnotateSubmitState(annotationServices[i].closest('fieldset'));
   }
 };
 

--- a/src/editor/utils/annotation.js
+++ b/src/editor/utils/annotation.js
@@ -15,12 +15,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { generateUUID } from "./../../util.js";
-import { tagsToBodyObjects } from "./../../doc.js";
+import { generateAttributeId } from "./../../util.js";
 import { fragmentFromString } from "../../utils/html.js";
 import { Icon } from "../../ui/icons.js";
 import Config from "../../config.js";
-import { generateDataURI } from "../../uri.js";
+import { generateDataURI, stripFragmentFromString } from "../../uri.js";
+import {
+  getSelectedParentElement,
+  rangeSelectsSingleNode,
+  exportSelection,
+  cloneSelection,
+  restoreSelection,
+  selectionToTextQuote,
+  selectionToSelectors,
+  setSelectionFromTextQuote,
+  setSelectionByOffset,
+  createAnnotation,
+  markSegmentHTML,
+} from '@dokieli/web-annotation';
 
 // 1. new annotation
 // replace the selection with fragment 
@@ -41,114 +53,34 @@ export function getTextQuoteHTML(refId, motivatedBy, selectedContent, docRefType
   if (typeof selectedContent !== "string") { throw new Error(`getTextQuoteHTML: selectedContent is of type ${typeof selectedContent}`) }
   if (!selectedContent.length) { throw new Error(`getTextQuoteHTML: selectedContent is empty`) }
 
-  refId = refId || generateUUID();
+  refId = refId || generateAttributeId();
   motivatedBy = motivatedBy || 'oa:replying';
   docRefType = docRefType || '';
   options = options || {};
 
-  var doMode = (options.do) ? ' do' : '';
-
-  var refOpen = '<span class="ref' + doMode + '" rel="schema:hasPart" resource="#' + refId + '" typeof="http://purl.org/dc/dcmitype/Text">';
-  var refClose = '</span>';
-  if (motivatedBy == 'oa:highlighting') {
-    refOpen = '<span class="ref' + doMode + '" rel="schema:hasPart" resource="#h-' + refId + '" typeof="oa:Annotation"><span rel="oa:motivatedBy" resource="oa:highlighting"></span><span rel="oa:hasTarget" resource="#' + refId + '" typeof="http://purl.org/dc/dcmitype/Text">';
-    refClose = '</span></span>';
-  }
-  var mark = '<mark datatype="rdf:HTML" id="' + refId + '" property="rdf:value">' + selectedContent + '</mark>';
-
-  return refOpen + mark + docRefType + refClose;
-}
-
-
-//Outputs:
-// {
-//   type: 'TextQuoteSelector',
-//   exact: 'ipsum',
-//   prefix: 'Lorem ',
-//   suffix: ' dolor'
-// }
-
-//From https://github.com/yabwe/medium-editor/blob/master/src/js/selection.js
-export function getSelectedParentElement(range) {
-  if (!range) {
-    return null;
-  }
-
-  // Selection encompasses a single element
-  if (rangeSelectsSingleNode(range) && range.startContainer.childNodes[range.startOffset].nodeType !== 3) {
-    return range.startContainer.childNodes[range.startOffset];
-  }
-
-  // Selection range starts inside a text node, so get its parent
-  if (range.startContainer.nodeType === 3) {
-    return range.startContainer.parentNode;
-  }
-
-  // Selection starts inside an element
-  return range.startContainer;
-}
-
-//From https://github.com/yabwe/medium-editor/blob/master/src/js/selection.js
-//http://stackoverflow.com/questions/15867542/range-object-get-selection-parent-node-chrome-vs-firefox
-export function rangeSelectsSingleNode(range) {
-  var startNode = range.startContainer;
-  return startNode === range.endContainer &&
-    startNode.hasChildNodes() &&
-    range.endOffset === range.startOffset + 1;
-}
-
-export function exportSelection(selectedParentElement, selection) {
-  if (!selection.rangeCount) return;
-
-  const ranges = [];
-
-  for (let i = 0; i < selection.rangeCount; i++) {
-    ranges.push(selection.getRangeAt(i));
-  }
-
-  const mergedRange = document.createRange();
-  mergedRange.setStart(ranges[0].startContainer, ranges[0].startOffset);
-  mergedRange.setEnd(ranges[ranges.length - 1].endContainer, ranges[ranges.length - 1].endOffset);
-
-  const preSelectionRange = mergedRange.cloneRange();
-  preSelectionRange.selectNodeContents(selectedParentElement);
-  preSelectionRange.setEnd(mergedRange.startContainer, mergedRange.startOffset);
-  const start = preSelectionRange.toString().length;
-
-  const selectionState = {
-    start: start,
-    end: start + mergedRange.toString().length
-  };
-
-  return selectionState;
-}
-
-export function cloneSelection() {
-  const selection = window.getSelection();
-  if (!selection.rangeCount) return null;
-
-  const clonedSelection = [];
-
-  for (let i = 0; i < selection.rangeCount; i++) {
-    const range = selection.getRangeAt(i).cloneRange();
-    const fragment = range.cloneContents();
-    clonedSelection.push({ range, fragment });
-  }
-
-  return clonedSelection;
-}
-
-//XXX: Note Firefox bug handling contenteditable true/false differently: https://bugzilla.mozilla.org/show_bug.cgi?id=818515
-export function restoreSelection(clonedSelection) {
-  const selection = window.getSelection();
-  selection.removeAllRanges(); // Clear existing selection
-
-  if (!clonedSelection) return;
-
-  clonedSelection.forEach(({ range }) => {
-    selection.addRange(range);
+  // The library builds the fragment markup (span dcterms:hasPart / mark rdf:value with id=refId);
+  // the reference marker (the <sup> tying it to the annotation) is passed as `reference`.
+  return markSegmentHTML(selectedContent, {
+    annotationUrl: options.annotationUrl || ('#' + refId),
+    id: refId,
+    className: options.do ? 'ref do' : 'ref',
+    reference: docRefType,
   });
 }
+
+
+export {
+  getSelectedParentElement,
+  rangeSelectsSingleNode,
+  exportSelection,
+  cloneSelection,
+  restoreSelection,
+  selectionToTextQuote,
+  setSelectionFromTextQuote,
+} from '@dokieli/web-annotation';
+
+// Re-exported under the original name for call sites that import setSelection
+export { setSelectionByOffset as setSelection } from '@dokieli/web-annotation';
 
 //FIXME: A bit hacky - should use RDF?
 //TODO: Move to inbox.js
@@ -207,6 +139,73 @@ export function createNoteData(annotation) {
       break;
   }
 
+  // dokieli maps its own UI action to a W3C motivation IRI (Config.ActionToMotivation,
+  // resolved by the caller into `motivatedBy`) and passes it directly to
+  // createAnnotation. The library no longer knows about dokieli "actions".
+  const annotationUser = {
+    iri: Config.User.IRI || undefined,
+    name: Config.User.Name || undefined,
+    // Never store the secret-agent placeholder; it's a display fallback the library adds
+    // (and dokieli re-adds when rendering an image-less annotation), not annotation data.
+    image: Config.User.Image || undefined,
+    url: Config.User.URL || undefined,
+    type: Config.User.Types || undefined
+  };
+
+  const textQuoteSelector = (selectionData && selectionData.selector) ? {
+    type: 'TextQuoteSelector',
+    exact: selectionData.selector.exact,
+    prefix: selectionData.selector.prefix,
+    suffix: selectionData.selector.suffix,
+    language: selectionLanguage
+  } : undefined;
+
+  // The library decides the selector shape from the live selection: a RangeSelector
+  // (XPath start/end refined by per-element TextQuotes) for cross-element selections,
+  // a FragmentSelector for same-element-with-id, else a plain TextQuoteSelector. It
+  // also captures each element's language. Fall back to the manual TextQuote when no
+  // live selection is available.
+  let targetSelector;
+  if (selectionData && selectionData.selection) {
+    try {
+      const { selectors = [] } = selectionToSelectors(selectionData.selection, {
+        container: selectionData.selectedParentElement,
+        contextLength: Config.ContextLength
+      }) || {};
+      targetSelector = selectors.find(s => s.type === 'RangeSelector')
+        || selectors.find(s => s.type === 'FragmentSelector')
+        || selectors.find(s => s.type === 'TextQuoteSelector');
+    } catch (e) {
+      // fall back to the manual TextQuoteSelector below
+    }
+  }
+
+  // Legacy fallback: anchor with a FragmentSelector (the element id) refined by the
+  // TextQuoteSelector when the target IRI carries a fragment, else the bare quote.
+  const targetFragment = (targetIRI && targetIRI.includes('#'))
+    ? targetIRI.substring(targetIRI.indexOf('#') + 1)
+    : null;
+
+  const fallbackSelector = textQuoteSelector
+    ? (targetFragment
+      ? {
+          type: 'FragmentSelector',
+          value: targetFragment,
+          conformsTo: 'https://tools.ietf.org/html/rfc3987',
+          refinedBy: textQuoteSelector
+        }
+      : textQuoteSelector)
+    : undefined;
+
+  const annotationTarget = {
+    iri: targetIRI,
+    source: resourceIRI,
+    language: targetLanguage,
+    selector: targetSelector || fallbackSelector,
+    renderedVia: { iri: 'https://dokie.li/#i', name: 'dokieli' }
+    //TODO: state
+  };
+
   switch (action) {
     // case 'sparkline':
     //   var figureIRI = generateAttributeId(null, opts.selectionDataSet);
@@ -220,60 +219,19 @@ export function createNoteData(annotation) {
       //XXX: No need to replace the nodes with itself.
       // ref = selectionData.selectedContent;
 
-      noteData = {
-        "type": action,
-        "mode": mode,
-        "motivatedByIRI": motivatedBy,
-        "id": id,
-        "canonical": 'urn:uuid:' + id,
-        "refId": refId,
-        "refLabel": refLabel,
-        // "iri": noteIRI, //e.g., https://example.org/path/to/article
-        "creator": {},
-        "datetime": datetime,
-        "target": {
-          "iri": targetIRI,
-          "source": resourceIRI,
-          "selector": {
-            "exact": selectionData.selector.exact,
-            "prefix": selectionData.selector.prefix,
-            "suffix": selectionData.selector.suffix,
-            "language": selectionLanguage
-          },
-          "language": targetLanguage
-          //TODO: state
-        }
-      };
-
-      var bodyObject = {
-        "value": content
-      };
-
-      if (language) {
-        noteData["language"] = language;
-        bodyObject["language"] = language;
-      }
-
-      if (license) {
-        noteData["rights"] = noteData["license"] = license;
-        bodyObject["rights"] = bodyObject["license"] = license;
-      }
-
-      noteData["body"] = [bodyObject].concat(tagsToBodyObjects(tagging));
-
-      if (Config.User.IRI) {
-        noteData.creator["iri"] = Config.User.IRI;
-      }
-
-      if (Config.User.Name) {
-        noteData.creator["name"] = Config.User.Name;
-      }
-
-      noteData.creator["image"] = Config.User.Image || Config.IconBase64['.fas.fa-user-secret'];
-
-      if (Config.User.URL) {
-        noteData.creator["url"] = Config.User.URL;
-      }
+      noteData = createAnnotation({
+        motivatedBy,
+        type: action,
+        id,
+        datetime,
+        language,
+        license,
+        rights: license,
+        target: annotationTarget,
+        body: { content, tags: tagging },
+        creator: annotationUser
+      });
+      noteData.mode = mode;
 
       if (annotationInboxLocation && Config.User.TypeIndex && Config.User.TypeIndex[ns.as.Announce.value]) {
         noteData.inbox = Config.User.TypeIndex[ns.as.Announce.value];
@@ -282,66 +240,22 @@ export function createNoteData(annotation) {
       break;
 
     case 'bookmark':
-      docRefType = '';
-
-      noteData = {
-        "type": action,
-        "mode": mode,
-        "motivatedByIRI": motivatedBy,
-        "id": id,
-        "canonical": 'urn:uuid:' + id,
-        "refId": refId,
-        "refLabel": refLabel,
-        // "iri": noteIRI, //e.g., https://example.org/path/to/article
-        "creator": {},
-        "datetime": datetime,
-        "target": {
-          "iri": targetIRI,
-          "source": resourceIRI,
-          "selector": {
-            "exact": selectionData.selector.exact,
-            "prefix": selectionData.selector.prefix,
-            "suffix": selectionData.selector.suffix,
-            "language": selectionLanguage
-          },
-          "language": targetLanguage
-          //TODO: state
-        }
-      };
-
-      var bodyObject = {
-        "purpose": "describing",
-        "value": content
-      };
-
-      if (language) {
-        noteData["language"] = language;
-        bodyObject["language"] = language;
-      }
-
-      if (license) {
-        noteData["rights"] = noteData["license"] = license;
-        bodyObject["rights"] = bodyObject["license"] = license;
-      }
-
-      noteData["body"] = [bodyObject].concat(tagsToBodyObjects(tagging));
-
-      if (Config.User.IRI) {
-        noteData.creator["iri"] = Config.User.IRI;
-      }
-
-      if (Config.User.Name) {
-        noteData.creator["name"] = Config.User.Name;
-      }
-
-      noteData.creator["image"] = Config.User.Image || Config.IconBase64['.fas.fa-user-secret'];
-
-      if (Config.User.URL) {
-        noteData.creator["url"] = Config.User.URL;
-      }
+      noteData = createAnnotation({
+        motivatedBy,
+        type: action,
+        id,
+        datetime,
+        language,
+        license,
+        rights: license,
+        target: annotationTarget,
+        body: { content, tags: tagging, purpose: 'describing' },
+        creator: annotationUser
+      });
+      noteData.mode = mode;
 
       // note = createNoteDataHTML(noteData);
-      ref = getTextQuoteHTML(refId, motivatedBy, selectionData.selectedContent, docRefType, { 'do': true });
+      ref = getTextQuoteHTML(refId, motivatedBy, selectionData.selectedContent, '', { 'do': true });
 
       break;
 
@@ -349,64 +263,22 @@ export function createNoteData(annotation) {
     case 'note':
       var docRefType = '<sup class="ref-comment"><a href="#' + id + '"rel="cito:isCitedBy">' + refLabel + '</a></sup>';
 
-      noteData = {
-        "type": action,
-        "mode": "read",
-        "motivatedByIRI": motivatedBy,
-        "id": id,
-        "canonical": 'urn:uuid:' + id,
-        "refId": refId,
-        "refLabel": refLabel,
-        // "iri": noteIRI, //e.g., https://example.org/path/to/article
-        "creator": {},
-        "datetime": datetime,
-        "target": {
-          "iri": targetIRI,
-          "source": resourceIRI,
-          "selector": {
-            "exact": selectionData.selector.exact,
-            "prefix": selectionData.selector.prefix,
-            "suffix": selectionData.selector.suffix,
-            "language": selectionLanguage
-          },
-          "language": targetLanguage
-          //TODO: state
-        }
-      };
-
-      var bodyObject = {
-        "purpose": "describing",
-        "value": content
-      };
-
-      if (language) {
-        noteData["language"] = language;
-        bodyObject["language"] = language;
-      }
-
-      if (license) {
-        noteData["rights"] = noteData["license"] = license;
-        bodyObject["rights"] = bodyObject["license"] = license;
-      }
-
-      noteData["body"] = [bodyObject].concat(tagsToBodyObjects(tagging));
-
-      if (Config.User.IRI) {
-        noteData.creator["iri"] = Config.User.IRI;
-      }
-
-      if (Config.User.Name) {
-        noteData.creator["name"] = Config.User.Name;
-      }
-
-      noteData.creator["image"] = Config.User.Image || Config.IconBase64['.fas.fa-user-secret'];
-
-      if (Config.User.URL) {
-        noteData.creator["url"] = Config.User.URL;
-      }
+      noteData = createAnnotation({
+        motivatedBy,
+        type: action,
+        id,
+        datetime,
+        language,
+        license,
+        rights: license,
+        target: annotationTarget,
+        body: { content, tags: tagging, purpose: 'describing' },
+        creator: annotationUser
+      });
+      noteData.mode = 'read';
 
       ref = getTextQuoteHTML(refId, motivatedBy, selectionData.selectedContent, docRefType);
-      Config.Editor.replaceSelectionWithFragment(fragmentFromString(ref));
+      Config.Editor.replaceSelectionWithInlineFragment(fragmentFromString(ref));
       break;
 
     case 'citation': //footnote reference
@@ -417,7 +289,7 @@ export function createNoteData(annotation) {
           noteData = {
             "type": refType,
             "mode": mode,
-            "motivatedByIRI": motivatedBy,
+            "motivatedBy": motivatedBy,
             "id": id,
             "refId": refId,
             "refLabel": refLabel,
@@ -451,7 +323,7 @@ export function createNoteData(annotation) {
 
       ref = getTextQuoteHTML(refId, motivatedBy, selectionData.selectedContent, docRefType);
 
-      Config.Editor.replaceSelectionWithFragment(fragmentFromString(ref));
+      Config.Editor.replaceSelectionWithInlineFragment(fragmentFromString(ref));
 
       break;
 
@@ -478,97 +350,26 @@ export function createNoteData(annotation) {
       break;
   }
 
-  // revisit when we refactor importTextQuoteSelector
-  // if (ref) {
-  //   // console.log(this.mode)
-  //   console.log(DO.Editor)
-  //   Config.Editor.replaceSelectionWithFragment(fragmentFromString(ref));
-  // }
+  // Annotation subject (about/@id), serializer-agnostic: write -> '' (resolves to the
+  // Location on POST), object -> relative '#id' (dokieli wraps it in a notification),
+  // read -> absolute documentURL#id (we already have the document URL).
+  if (noteData && noteData.id && noteData.mode) {
+    noteData.iri =
+      noteData.mode === 'write' ? ''
+      : noteData.mode === 'read' ? `${stripFragmentFromString(resourceIRI)}#${noteData.id}`
+      : `#${noteData.id}`;
+  }
 
   return noteData;
 }
 
-// Returns the text content of a node while skipping <sup> elements.
-// This is used so that annotation markup (<sup> labels) injected into the DOM
-// by previous showAnnotation calls does not shift character offsets for
-// subsequent annotations targeting the same passage.
+// textContent skipping <sup> subtrees, so reference markers injected by prior
+// annotations don't shift offsets across annotations on the same passage. dokieli
+// renders those markers; the @dokieli/web-annotation core is sup-agnostic.
 export function getTextContentExcludingSups(node) {
-  if (node.nodeType === Node.TEXT_NODE) return node.textContent;
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? '';
   if (node.tagName?.toUpperCase() === 'SUP') return '';
   let text = '';
-  for (const child of node.childNodes) {
-    text += getTextContentExcludingSups(child);
-  }
+  for (const child of node.childNodes) text += getTextContentExcludingSups(child);
   return text;
-}
-
-export function setSelection(start, end, containerNode) {
-  const range = document.createRange();
-  const selection = window.getSelection();
-
-  let currentNode = containerNode;
-  let charIndex = 0;
-
-  function traverseNodes(node) {
-    if (node.nodeType === Node.TEXT_NODE) {
-      let nextCharIndex = charIndex + node.textContent.length;
-      if (charIndex <= start && nextCharIndex >= start) {
-        range.setStart(node, start - charIndex);
-      }
-      if (charIndex <= end && nextCharIndex >= end) {
-        range.setEnd(node, end - charIndex);
-      }
-      charIndex = nextCharIndex;
-    }
-    else if (node.tagName?.toUpperCase() !== 'SUP') {
-      for (let i = 0; i < node.childNodes.length; i++) {
-        traverseNodes(node.childNodes[i]);
-      }
-    }
-  }
-
-  traverseNodes(currentNode);
-
-  selection.removeAllRanges();
-  selection.addRange(range);
-}
-
-const QUOTE_CONTEXT_LENGTH = 32;
-
-export function selectionToTextQuote(containerNode, selection) {
-  if (!selection.rangeCount) return null;
-  const range = selection.getRangeAt(0);
-  const exact = range.toString();
-
-  const preRange = document.createRange();
-  preRange.selectNodeContents(containerNode);
-  preRange.setEnd(range.startContainer, range.startOffset);
-  const prefix = preRange.toString().slice(-QUOTE_CONTEXT_LENGTH);
-
-  const postRange = document.createRange();
-  postRange.selectNodeContents(containerNode);
-  postRange.setStart(range.endContainer, range.endOffset);
-  const suffix = postRange.toString().slice(0, QUOTE_CONTEXT_LENGTH);
-
-  return { exact, prefix, suffix };
-}
-
-export function setSelectionFromTextQuote(containerNode, { exact, prefix, suffix }) {
-  const text = getTextContentExcludingSups(containerNode);
-  const search = (prefix || '') + exact + (suffix || '');
-
-  let start = -1;
-  if (search.length > 0) {
-    const idx = text.indexOf(search);
-    if (idx !== -1) start = idx + (prefix || '').length;
-  }
-
-  if (start === -1 && exact) {
-    start = text.indexOf(exact);
-  }
-
-  if (start === -1) return false;
-
-  setSelection(start, start + exact.length, containerNode);
-  return true;
 }

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import Config from './config.js'
-import { generateUUID } from './util.js'
+import { generateAttributeId } from './util.js'
 import { getProxyableIRI, currentLocation } from './uri.js'
 import { domSanitize } from './utils/sanitization.js'
 
@@ -458,7 +458,7 @@ function patchResourceGraph (url, patches, options = {}) {
 
     case 'text/n3':
     default :
-      var patchId = '_:' + generateUUID();
+      var patchId = '_:' + generateAttributeId();
       data += `${patchId} a solid:InsertDeletePatch .\n`;
       var deletes = '';
       patches.forEach(patch => {

--- a/src/graph.js
+++ b/src/graph.js
@@ -24,6 +24,7 @@ import { escapeRegExp, scoreMatch, uniqueArray } from './util.js'
 import { domSanitize, safeObjectAssign, sanitizeInsertAdjacentHTML, sanitizeIRI, sanitizeIRIOrBNode, sanitizeIRIs, sanitizeObject } from './utils/sanitization.js'
 import { parseMarkdown } from "./utils/html.js";
 import { getResource, setAcceptRDFTypes } from './fetcher.js'
+import { serializeAnnotationToJSONLD, parseAnnotation } from '@dokieli/web-annotation';
 import LinkHeader from "http-link-header";
 
 const ns = Config?.ns;
@@ -196,7 +197,8 @@ export function getSubjectInfo(subjectIRI, options = {}) {
         Occupations: getAgentOccupations(g),
         Skills: getGraphSkills(g),
         Publications: getAgentPublications(g),
-        Made: getAgentMade(g)
+        Made: getAgentMade(g),
+        Types: getGraphTypes(g)
       }
     })
   }
@@ -237,6 +239,15 @@ export function serializeDataToPreferredContentType(data, options) {
     case 'application/json':
     case '*/*':
     default:
+      // Prefer model-built JSON-LD when the caller supplies it (clean, no RDFa-derived
+      // langStrings): a pre-wrapped AS activity (activityJSONLD) or the annotation model
+      // (annotationObject) serialized directly. Fall back to the legacy RDFa → graph path.
+      if (options.activityJSONLD) {
+        return Promise.resolve(JSON.stringify(options.activityJSONLD));
+      }
+      if (options.annotationObject) {
+        return Promise.resolve(JSON.stringify(serializeAnnotationToJSONLD(options.annotationObject)));
+      }
       return serializeData(data, options['contentType'], 'application/ld+json', options);
   }
 }
@@ -474,6 +485,61 @@ function streamToString(stream) {
     stream.on('error', (err) => reject(err));
     stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
   })
+}
+
+/**
+ * Descends an LDN/ActivityStreams notification wrapper, following `as:object`
+ * (cycle-guarded) to the inner `oa:Annotation`, and returns its IRI. Unwrapping
+ * the notification envelope is dokieli's job, not the annotations library's, so
+ * we resolve it here before handing a plain annotation IRI to core's parser.
+ *
+ * @param {object} g - rdf-ext graph (grapoi dataset).
+ * @param {string} [annotationIRI] - wrapper or annotation IRI.
+ * @returns {string|undefined} The inner annotation IRI, or the input unchanged.
+ */
+function unwrapToAnnotationIRI(g, annotationIRI) {
+  if (!annotationIRI) { return annotationIRI; }
+
+  const seen = new Set();
+  let iri = annotationIRI;
+
+  while (iri && !seen.has(iri)) {
+    seen.add(iri);
+    const node = g.node(rdf.namedNode(iri));
+    if (node.out(ns.rdf.type).values.includes(ns.oa.Annotation.value)) { return iri; }
+    const object = node.out(ns.as.object).values[0];
+    if (!object) { break; }
+    iri = object;
+  }
+
+  return annotationIRI;
+}
+
+/**
+ * Parses an annotation out of an rdf-ext graph into an `@dokieli/web-annotation`
+ * `Annotation`, using core's `parseAnnotation` with a `JSONLDParser` backed by
+ * our rdf-ext serializer. Because the graph is already RDF (any source format —
+ * RDFa/Turtle/JSON-LD), this works regardless of how the resource was fetched.
+ *
+ * @param {object} g - rdf-ext graph (grapoi dataset).
+ * @param {string} [annotationIRI] - IRI to pick the annotation node (may be a notification wrapper); also set as `annotation.iri`.
+ * @returns {Promise<object|null>} The parsed Annotation, or null.
+ */
+export function parseAnnotationFromGraph(g, annotationIRI) {
+  const resolvedIRI = unwrapToAnnotationIRI(g, annotationIRI);
+
+  // The JSONLDParser: rdf-ext graph → JSON-LD. core maps it to an Annotation.
+  const parser = async (graph) => {
+    // Serialize the WHOLE dataset, not just the resource term's outbound quads.
+    // getResourceGraph scopes the grapoi to the resource IRI, so g.out().quads()
+    // emits only the annotation node's direct triples — dropping the target
+    // SpecificResource and the selector (separate subjects), which left annotations
+    // with no selector and therefore no mark. Re-wrap as a term-less grapoi.
+    const fullGraph = graph?.dataset ? rdf.grapoi({ dataset: graph.dataset }) : graph;
+    const jsonld = await serializeGraph(fullGraph, { contentType: 'application/ld+json' });
+    return jsonld ? JSON.parse(jsonld) : [];
+  };
+  return parseAnnotation(g, { parser, annotationIRI: resolvedIRI });
 }
 
 export function serializeGraph(g, options = {}) {
@@ -740,6 +806,16 @@ export function getResourceGraph(iri, headers, options = {}) {
       }
       else if (!Config.MediaTypes.RDF.includes(options['contentType'])) {
         return Promise.reject(new Error('Unsupported media type for RDF parsing: ' + options['contentType']));
+      }
+
+      if (['application/ld+json', 'application/activity+json'].includes(options['contentType'])) {
+        return response.text().then(text => {
+          try {
+            return JSON.stringify(transformJsonldContextURLScheme(JSON.parse(text)));
+          } catch (e) {
+            return text;
+          }
+        });
       }
 
       return response.text();

--- a/src/storage.js
+++ b/src/storage.js
@@ -46,7 +46,7 @@ async function del(key) {
 }
 
 import Config from './config.js';
-import { getDateTimeISO, generateUUID } from './util.js';
+import { getDateTimeISO, generateAttributeId } from './util.js';
 import { getDocument, updateMutableResource } from './doc.js';
 
 export async function updateDeviceStorageDocumentWithItem(key, data, options = {}) {
@@ -64,7 +64,7 @@ export async function updateDeviceStorageDocumentWithItem(key, data, options = {
   var collection = await getDeviceStorageItem(key);
   // console.log(collection);
 
-  var id = `${key}#${generateUUID()}`;
+  var id = `${key}#${generateAttributeId()}`;
 
   var datetime = getDateTimeISO();
 
@@ -294,7 +294,7 @@ export function updateDeviceStorageProfile(User) {
   var U = { ...User };
   var key = 'DO.Config.User';
 
-  var id = generateUUID();
+  var id = generateAttributeId();
   var datetime = getDateTimeISO();
 
   // Graphs are large and reconstructable, so we don't persist them.

--- a/src/storage/backend.js
+++ b/src/storage/backend.js
@@ -91,8 +91,11 @@ class StorageBackend {
   patchWithConneg(_url, _patch, _options) {
     return Promise.reject(new Error("not implemented"));
   }
-  getAcceptPost(_url) {
-    return Promise.reject(new Error("not implemented"));
+  // Generic: query the endpoint's Accept-Post via OPTIONS, falling back to
+  // application/ld+json. Applies to any HTTP endpoint (e.g. plain HTTP inboxes),
+  // so it lives on the base rather than only SolidStorage.
+  getAcceptPost(url) {
+    return getAcceptPostPreference(url);
   }
 }
 
@@ -368,9 +371,6 @@ class SolidStorage extends StorageBackend {
   }
   patchWithConneg(url, patch, options) {
     return patchResourceWithAcceptPatch(url, patch, options);
-  }
-  getAcceptPost(url) {
-    return getAcceptPostPreference(url);
   }
 }
 

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -509,6 +509,12 @@ export function createHTML(title, main, options) {
   lang = ' lang="' + lang + '" xml:lang="' + lang + '"';
   lang = ('omitLang' in options) ? '' : lang;
 
+  // `options.sanitized` lets a caller pass already-trusted generated markup (e.g. the
+  // annotation RDFa, where only the user input was sanitized at the boundary) so the
+  // whole document isn't re-sanitized - which both strips the wrapper down to <main>
+  // and can alter the generated RDFa. Default still sanitizes for untrusted callers.
+  var mainHTML = ('sanitized' in options) ? main : domSanitize(main);
+
   let html = `<!DOCTYPE html>
 <html${lang} xmlns="http://www.w3.org/1999/xhtml">
   <head>
@@ -517,7 +523,7 @@ export function createHTML(title, main, options) {
   </head>
   <body${prefix}>
     <main>
-${domSanitize(main)}
+${mainHTML}
     </main>
   </body>
 </html>

--- a/tests/unit/activity.test.js
+++ b/tests/unit/activity.test.js
@@ -15,10 +15,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { sendNotifications } from 'src/activity.js';  
-import { setupMockFetch, resetMockFetch } from '../utils/mockFetch';  
+import { sendNotifications, showActivities, showActivitiesSources } from 'src/activity.js';
+import { setupMockFetch, resetMockFetch } from '../utils/mockFetch';
 import Config from '../../src/config';
 import MockGrapoi from '../utils/mockGrapoi';
+
+describe('activity read dedup', () => {
+  beforeEach(() => {
+    resetMockFetch();
+    setupMockFetch({});
+  });
+
+  // Concurrent reads for the same URL must collapse to one in-flight promise so a
+  // document's overlapping scans don't storm the storage server into a 429.
+  test('showActivities returns the same in-flight promise for concurrent same-URL calls', () => {
+    const url = 'https://example.org/dedup/activity-' + Math.random();
+    const a = showActivities(url);
+    const b = showActivities(url);
+    a.catch(() => {}); b.catch(() => {});
+    expect(a).toBe(b);
+  });
+
+  test('showActivitiesSources returns the same in-flight promise for concurrent same-URL calls', () => {
+    const url = 'https://example.org/dedup/container-' + Math.random();
+    const a = showActivitiesSources(url);
+    const b = showActivitiesSources(url);
+    a.catch(() => {}); b.catch(() => {});
+    expect(a).toBe(b);
+  });
+
+  test('distinct URLs are not deduped against each other', () => {
+    const a = showActivitiesSources('https://example.org/dedup/c1-' + Math.random());
+    const b = showActivitiesSources('https://example.org/dedup/c2-' + Math.random());
+    a.catch(() => {}); b.catch(() => {});
+    expect(a).not.toBe(b);
+  });
+});
 
 describe('sendNotifications', () => {
   beforeEach(() => {

--- a/tests/unit/editor/utils/annotation.test.js
+++ b/tests/unit/editor/utils/annotation.test.js
@@ -21,6 +21,7 @@ import {
   getSelectedParentElement,
   exportSelection,
   cloneSelection,
+  getTextContentExcludingSups,
 } from "../../../../src/editor/utils/annotation";
 
 describe("getTextQuoteHTML", () => {
@@ -137,6 +138,26 @@ describe("exportSelection", () => {
 
     const result = exportSelection(el, selection);
     expect(result).toEqual({ start: 0, end: 5 });
+  });
+});
+
+describe("getTextContentExcludingSups", () => {
+  it("returns concatenated text from text nodes and non-SUP elements", () => {
+    const container = document.createElement("div");
+    container.innerHTML = "<p>Hello <em>world</em></p>";
+    expect(getTextContentExcludingSups(container)).toBe("Hello world");
+  });
+
+  it("skips contents of <sup> subtrees", () => {
+    const container = document.createElement("div");
+    container.innerHTML = "<p>Hello<sup>123</sup> world</p>";
+    expect(getTextContentExcludingSups(container)).toBe("Hello world");
+  });
+
+  it("skips nested <sup> within other elements", () => {
+    const container = document.createElement("div");
+    container.innerHTML = "<p>a <span>b<sup>X</sup>c</span> d</p>";
+    expect(getTextContentExcludingSups(container)).toBe("a bc d");
   });
 });
 

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -32,7 +32,7 @@ vi.mock('src/util.js', async () => {
   return {
     ...actual,
     fragmentFromString: vi.fn(() => document.createElement('div')),
-    generateUUID: vi.fn(() => 'uuid-123'),
+    generateAttributeId: vi.fn(() => 'uuid-123'),
     getDateTimeISO: vi.fn(() => '2024-05-21T12:00:00Z'),
     getHash: vi.fn(() => Promise.resolve('hash123')),
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,6 +290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dokieli/web-annotation@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@dokieli/web-annotation@npm:1.0.0"
+  checksum: 10c0/e054e78b4015b299271e0c2a90635f5fe053d3a2533da79287203d667901f78cb49d2dc5bf3b3c1b8fc298c14e9357d0c8612f660a014f856ce51f42473ebb54
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/core@npm:1.10.0"
@@ -2097,6 +2104,7 @@ __metadata:
   resolution: "dokieli@workspace:."
   dependencies:
     "@axe-core/playwright": "npm:^4.9.1"
+    "@dokieli/web-annotation": "npm:^1.0.0"
     "@playwright/test": "npm:^1.44.1"
     "@uvdsl/solid-oidc-client-browser": "npm:^0.2.3"
     "@vitest/coverage-istanbul": "npm:^4.0.18"


### PR DESCRIPTION
This PR integrates the [@dokieli/web-annotation](https://github.com/dokieli/web-annotation) package. The original code was extracted from dokieli to be its own module, and extended, e.g.:

* allow the UI to handle range selections across nodes.
* additional Web Annotation Selectors such as `RangeSelector`, `XPathSelector`, `TextPositionSelector`.
* additional States such as `TimeState`, `HttpRequestState`.
* ...

A public announcement: https://lists.w3.org/Archives/Public/public-socialweb/2026Aug/0007.html