### PR TITLE
Refactor: generalize keystore for multiple purposes

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -159,7 +159,10 @@ export async function signOut() {
 
   Config.User = {
     IRI: null,
-    Encryption: { Enabled: false, KeyId: null, KeystoreURL: null, PodSyncFailed: false },
+    Keys: {
+      Encryption: { Enabled: false, KeyId: null, KeystoreURL: null, StorageSyncFailed: false },
+      Signing: { Enabled: false, KeyId: null, KeystoreURL: null, StorageSyncFailed: false }
+    },
     UI: Config.User.UI
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -40,13 +40,22 @@ export default {
   User: {
     IRI: null,
     Role: null,
-    Encryption: {
-      Enabled: false,
-      KeyId: null,
-      KeystoreURL: null,
-      PodSyncFailed: false,
-      Document: false,
-      DocumentEncrypt: false
+    Keys: {
+      Encryption: {
+        Enabled: false,
+        KeyId: null,
+        KeystoreURL: null,
+        StorageSyncFailed: false,
+        Document: false,
+        DocumentEncrypt: false,
+        Scope: 'article'
+      },
+      Signing: {
+        Enabled: false,
+        KeyId: null,
+        KeystoreURL: null,
+        StorageSyncFailed: false
+      }
     },
     UI: {
       Language: 'en-GB', // default

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -34,9 +34,23 @@ export async function generateEncryptionKeypair() {
   return { publicKey, privateKey, kid };
 }
 
+// RSA-2048 with SHA-256 is what the nanopub network verifies signatures with
+export async function generateSigningKeypair() {
+  const { publicKey, privateKey } = await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['sign', 'verify']
+  );
+  const jwk = await crypto.subtle.exportKey('jwk', publicKey);
+  const kid = await calculateJwkThumbprint(jwk);
+  return { publicKey, privateKey, kid };
+}
+
+// use records what the key is for; the thumbprint covers only required members, so kid is unaffected
 export async function exportPublicKeyJWK(publicKey, kid) {
   const jwk = await crypto.subtle.exportKey('jwk', publicKey);
-  return kid ? { ...jwk, kid } : jwk;
+  const use = jwk.kty === 'RSA' ? 'sig' : 'enc';
+  return kid ? { ...jwk, use, kid } : { ...jwk, use };
 }
 
 export async function exportPrivateKeyJWK(privateKey, kid) {
@@ -44,24 +58,21 @@ export async function exportPrivateKeyJWK(privateKey, kid) {
   return kid ? { ...jwk, kid } : jwk;
 }
 
+// EC keys are for key agreement, RSA keys for nanopub signatures
+function algorithmFor(jwk) {
+  return jwk?.kty === 'RSA'
+    ? { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }
+    : { name: 'ECDH', namedCurve: CURVE };
+}
+
 export async function importPublicKeyJWK(jwk) {
-  return crypto.subtle.importKey(
-    'jwk',
-    jwk,
-    { name: 'ECDH', namedCurve: CURVE },
-    true,
-    []
-  );
+  const usages = jwk?.kty === 'RSA' ? ['verify'] : [];
+  return crypto.subtle.importKey('jwk', jwk, algorithmFor(jwk), true, usages);
 }
 
 export async function importPrivateKeyJWK(jwk) {
-  return crypto.subtle.importKey(
-    'jwk',
-    jwk,
-    { name: 'ECDH', namedCurve: CURVE },
-    false,
-    ['deriveBits']
-  );
+  const usages = jwk?.kty === 'RSA' ? ['sign'] : ['deriveBits'];
+  return crypto.subtle.importKey('jwk', jwk, algorithmFor(jwk), false, usages);
 }
 
 function toPEM(buffer, label) {
@@ -77,18 +88,30 @@ function fromPEM(pem) {
   return bytes.buffer;
 }
 
-// EC private JWK carries x and y, so the public key needs no second file
+// PKCS#8 does not say which algorithm to import as, so try key agreement first and fall back to signing
+async function importPKCS8(pem) {
+  const der = fromPEM(pem);
+  try {
+    return await crypto.subtle.importKey('pkcs8', der, { name: 'ECDH', namedCurve: CURVE }, true, ['deriveBits']);
+  } catch {
+    return crypto.subtle.importKey('pkcs8', der, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['sign']);
+  }
+}
+
+// The private JWK carries the public members too, so the public key needs no second file
 export async function privateKeyPEMToJWK(pem) {
-  const key = await crypto.subtle.importKey('pkcs8', fromPEM(pem), { name: 'ECDH', namedCurve: CURVE }, true, ['deriveBits']);
-  const jwk = await crypto.subtle.exportKey('jwk', key);
-  const publicKeyJWK = { crv: jwk.crv, ext: true, key_ops: [], kty: jwk.kty, x: jwk.x, y: jwk.y };
+  const jwk = await crypto.subtle.exportKey('jwk', await importPKCS8(pem));
+  const publicKeyJWK = jwk.kty === 'RSA'
+    ? { e: jwk.e, ext: true, key_ops: [], kty: jwk.kty, n: jwk.n, use: 'sig' }
+    : { crv: jwk.crv, ext: true, key_ops: [], kty: jwk.kty, use: 'enc', x: jwk.x, y: jwk.y };
   const kid = await calculateJwkThumbprint(publicKeyJWK);
   return { privateKeyJWK: { ...jwk, kid }, publicKeyJWK: { ...publicKeyJWK, kid } };
 }
 
 // Extractable, unlike importPrivateKeyJWK: this key is handed to the user
 export async function privateKeyJWKToPEM(privateKeyJWK) {
-  const key = await crypto.subtle.importKey('jwk', privateKeyJWK, { name: 'ECDH', namedCurve: CURVE }, true, ['deriveBits']);
+  const usages = privateKeyJWK?.kty === 'RSA' ? ['sign'] : ['deriveBits'];
+  const key = await crypto.subtle.importKey('jwk', privateKeyJWK, algorithmFor(privateKeyJWK), true, usages);
   return toPEM(await crypto.subtle.exportKey('pkcs8', key), 'PRIVATE KEY');
 }
 

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -559,7 +559,7 @@ export function initDocumentDoEvents() {
     }
 
     const setDocumentEncrypt = (value) => {
-      Config.User.Encryption.DocumentEncrypt = value;
+      Config.User.Keys.Encryption.DocumentEncrypt = value;
       refreshEncryptToggle();
       if (value) {
         ensureEncryptedDocumentACL().catch(e => console.warn('dokieli: could not restrict access on encrypted document', e));
@@ -1148,7 +1148,7 @@ export function shareResource(listenerEvent, iri) {
 
 // For encrypted documents: grant Read, re-encrypt to the recipients' published keys, then notify. Contacts without a published encryption key are skipped so they are not announced content they cannot decrypt
 async function shareResourceWithAgents(tos, note, iri, shareResourceNode) {
-  if (!(Config.User.Encryption?.Enabled && Config.User.Encryption?.DocumentEncrypt)) {
+  if (!(Config.User.Keys?.Encryption?.Enabled && Config.User.Keys?.Encryption?.DocumentEncrypt)) {
     return sendNotifications(tos, note, iri, shareResourceNode);
   }
 
@@ -1255,7 +1255,7 @@ export function addShareResourceContactInput(node, agent) {
   var inbox = agent?.Inbox;
 
   // An encrypted document can only be shared with agents whose profile publishes an encryption key
-  if (Config.User.Encryption?.Enabled && Config.User.Encryption?.DocumentEncrypt && !agentHasPublishedEncryptionKey(agent?.Graph)) {
+  if (Config.User.Keys?.Encryption?.Enabled && Config.User.Keys?.Encryption?.DocumentEncrypt && !agentHasPublishedEncryptionKey(agent?.Graph)) {
     return;
   }
 
@@ -3961,7 +3961,7 @@ export async function saveAsDocument(e) {
       saveData = payload.data;
       saveContentType = payload.contentType;
     }
-    else if (Config.User.Encryption?.Enabled && Config.User.Encryption?.DocumentEncrypt) {
+    else if (Config.User.Keys?.Encryption?.Enabled && Config.User.Keys?.Encryption?.DocumentEncrypt) {
       saveData = await encryptArticlePayload(saveData);
     }
 
@@ -7335,11 +7335,11 @@ function initPassphraseToggles(container) {
   });
 }
 
-// Asks whether to encrypt the article's content only or the whole document, then records the choice on Config.User.Encryption.Scope and continues (to the passphrase step)
+// Asks whether to encrypt the article's content only or the whole document, then records the choice on Config.User.Keys.Encryption.Scope and continues (to the passphrase step)
 export function showEncryptionScopeChoice(onChosen) {
   if (document.getElementById('encryption-scope')) return;
 
-  const currentScope = Config.User.Encryption?.Scope === 'document' ? 'document' : 'article';
+  const currentScope = Config.User.Keys?.Encryption?.Scope === 'document' ? 'document' : 'article';
   const buttonClose = getButtonHTML({ button: 'close', buttonClass: 'close', iconSize: 'fa-2x' });
 
   const html = `
@@ -7371,7 +7371,7 @@ export function showEncryptionScopeChoice(onChosen) {
   aside.querySelector('#encryption-scope-form').addEventListener('submit', e => {
     e.preventDefault();
     const selected = aside.querySelector('input[name="encryption-scope"]:checked')?.value;
-    Config.User.Encryption.Scope = selected === 'document' ? 'document' : 'article';
+    Config.User.Keys.Encryption.Scope = selected === 'document' ? 'document' : 'article';
     aside.remove();
     onChosen?.();
   });
@@ -7448,17 +7448,17 @@ export function showEncryptionSetup(onSuccess) {
 
     try {
       await createKeystore(pass);
-      Config.User.Encryption.Enabled = true;
-      Config.User.Encryption.KeyId = getSessionKid();
+      Config.User.Keys.Encryption.Enabled = true;
+      Config.User.Keys.Encryption.KeyId = getSessionKid();
       generatingMsg.remove();
       const successMsg = document.createElement('p');
       successMsg.setAttribute('data-i18n', 'encryption-setup.success');
       successMsg.textContent = i18n.t('encryption-setup.success.textContent');
       info.appendChild(successMsg);
 
-      const keystoreURL = Config.User.Encryption.KeystoreURL;
+      const keystoreURL = Config.User.Keys.Encryption.KeystoreURL;
       const locationMsg = document.createElement('p');
-      if (keystoreURL && !Config.User.Encryption.StorageSyncFailed) {
+      if (keystoreURL && !Config.User.Keys.Encryption.StorageSyncFailed) {
         locationMsg.setAttribute('data-i18n', 'encryption-setup.saved-at');
         locationMsg.setHTMLUnsafe(domSanitize(i18n.t('encryption-setup.saved-at.textContent') + ' <a href="' + keystoreURL + '" rel="noopener" target="_blank">' + keystoreURL + '</a>'));
         info.appendChild(locationMsg);
@@ -7490,7 +7490,7 @@ export function showEncryptionSetup(onSuccess) {
 
       clearPendingEncryptedQueues();
       onSuccess?.();
-      if (Config.User.Encryption.StorageSyncFailed) {
+      if (Config.User.Keys.Encryption.StorageSyncFailed) {
         // Defer profile publication until the keystore reaches storage, on a later unlock
         const syncMsg = document.createElement('p');
         syncMsg.setAttribute('class', 'warning');
@@ -7748,8 +7748,8 @@ export function showEncryptionUnlock(onSuccess) {
 
     try {
       await unlockKeystore(pass);
-      Config.User.Encryption.Enabled = true;
-      Config.User.Encryption.KeyId = getSessionKid();
+      Config.User.Keys.Encryption.Enabled = true;
+      Config.User.Keys.Encryption.KeyId = getSessionKid();
 
       const { decryptArticleInPlace } = await import('./init.js');
       await decryptArticleInPlace();

--- a/src/doc.js
+++ b/src/doc.js
@@ -2183,7 +2183,7 @@ export async function createMutableResource(url, data, options) {
 
   // First serialize: document carries the mutableURL identifier (rel:latest-version).
   data = getDocument(null, documentOptions);
-  if (Config.User.Encryption?.Enabled && Config.User.Encryption?.DocumentEncrypt) data = await encryptArticlePayload(data);
+  if (Config.User.Keys?.Encryption?.Enabled && Config.User.Keys?.Encryption?.DocumentEncrypt) data = await encryptArticlePayload(data);
 
   Config.Storage.save(containerIRI, uuid, data, options)
     .then((resolved) => handleActionMessage(resolved))
@@ -2195,7 +2195,7 @@ export async function createMutableResource(url, data, options) {
   setDocumentRelation(document, [r], o);
 
   data = getDocument(null, documentOptions);
-  if (Config.User.Encryption?.Enabled && Config.User.Encryption?.DocumentEncrypt) data = await encryptArticlePayload(data);
+  if (Config.User.Keys?.Encryption?.Enabled && Config.User.Keys?.Encryption?.DocumentEncrypt) data = await encryptArticlePayload(data);
 
   Config.Storage.save(url, null, data, options)
     .then((resolved) => handleActionMessage(resolved))
@@ -2215,7 +2215,7 @@ export async function encryptArticlePayload(htmlString) {
   if (!article) return htmlString;
 
   const titleNode = parsed.querySelector('head > title');
-  const scope = Config.User.Encryption?.Scope === 'document' ? 'document' : 'article';
+  const scope = Config.User.Keys?.Encryption?.Scope === 'document' ? 'document' : 'article';
 
   let plaintext;
   let hiddenHeadNodes = [];
@@ -2259,7 +2259,7 @@ export async function encryptArticlePayload(htmlString) {
 
   if (titleNode) titleNode.textContent = i18n.t('encryption.encrypted-document-title.textContent');
 
-  Config.User.Encryption.Document = true;
+  Config.User.Keys.Encryption.Document = true;
 
   const doctype = getDoctype();
   return (doctype ? doctype + '\n' : '') + parsed.documentElement.outerHTML;
@@ -2321,7 +2321,7 @@ export async function updateMutableResource(url, data, options) {
   data = payload.data;
   options.contentType = payload.contentType;
 
-  if (Config.User.Encryption?.Enabled && Config.User.Encryption?.DocumentEncrypt) data = await encryptArticlePayload(data);
+  if (Config.User.Keys?.Encryption?.Enabled && Config.User.Keys?.Encryption?.DocumentEncrypt) data = await encryptArticlePayload(data);
 
   Config.Storage.save(url, null, data, options)
     .then(async (resolved) => {

--- a/src/init.js
+++ b/src/init.js
@@ -140,7 +140,7 @@ function initUser() {
       // user.object.describes.Role = (Config.User.IRI && user.object.describes.Role) ? user.object.describes.Role : 'social';
 
       // Restore user info only, do not fetch profile or TypeIndex here. Auth (restoreSession) runs in parallel and may not have completed yet, so any authenticated fetch here gets a 401. The dokieli:auth-ready event fires after initAuth completes and triggers setUserInfo + afterSetUserInfo with a live session.
-      Config.User = { Encryption: { Enabled: false, KeyId: null }, ...sanitizeObject(user.object.describes) };
+      Config.User = { Keys: { Encryption: { Enabled: false, KeyId: null }, Signing: { Enabled: false, KeyId: null } }, ...sanitizeObject(user.object.describes) };
     }
   })
 }
@@ -586,8 +586,8 @@ export async function initEncryptedDocument() {
   const encryptedScript = document.getElementById('dokieli-e2ee');
   if (!encryptedScript) {
     // Per-document state: a newly loaded document without an encrypted payload starts unencrypted regardless of the previous document's toggle
-    Config.User.Encryption.Document = false;
-    Config.User.Encryption.DocumentEncrypt = false;
+    Config.User.Keys.Encryption.Document = false;
+    Config.User.Keys.Encryption.DocumentEncrypt = false;
     return;
   }
 
@@ -643,19 +643,19 @@ export async function decryptArticleInPlace() {
     const tmpl = document.createElement('template');
     tmpl.innerHTML = body;
     shell.replaceWith(tmpl.content);
-    Config.User.Encryption.Scope = 'document';
+    Config.User.Keys.Encryption.Scope = 'document';
   }
   else {
     article.removeAttribute('data-encrypted');
     article.setHTMLUnsafe(body);
-    Config.User.Encryption.Scope = 'article';
+    Config.User.Keys.Encryption.Scope = 'article';
   }
   if (title) document.title = title;
 
-  Config.User.Encryption.Enabled = true;
-  Config.User.Encryption.KeyId = getSessionKid();
-  Config.User.Encryption.Document = true;
-  Config.User.Encryption.DocumentEncrypt = true;
+  Config.User.Keys.Encryption.Enabled = true;
+  Config.User.Keys.Encryption.KeyId = getSessionKid();
+  Config.User.Keys.Encryption.Document = true;
+  Config.User.Keys.Encryption.DocumentEncrypt = true;
 }
 
 // function initMath(config) {

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -19,6 +19,7 @@ import rdf from 'rdf-ext';
 import Config from './config.js';
 import {
   generateEncryptionKeypair,
+  generateSigningKeypair,
   exportPublicKeyJWK,
   exportPrivateKeyJWK,
   importPublicKeyJWK,
@@ -39,19 +40,31 @@ import { applyACLPlan, getACLContext } from './wac.js';
 import { forceTrailingSlash, stripFragmentFromString } from './uri.js';
 import { escapeRDFLiteral, generateUUID } from './util.js';
 
-// Non-extractable private keys by kid; sessionKid is the current key used for new encryption
-let sessionPrivateKeys = new Map();
-let sessionPublicKey = null;
-let sessionPublicKeyJWK = null;
-let sessionKid = null;
+export const KEY_AGREEMENT = 'keyAgreement';
+export const ASSERTION = 'assertion';
+const PURPOSES = [KEY_AGREEMENT, ASSERTION];
 
-let cachedKeystoreURL = null;
-let storageChecked = false;
+// Non-extractable private keys by kid; kid is the current key used for new operations of that purpose
+function newSession() {
+  return { privateKeys: new Map(), publicKey: null, publicKeyJWK: null, kid: null, keystoreURL: null, storageChecked: false };
+}
+
+let sessions = { [KEY_AGREEMENT]: newSession(), [ASSERTION]: newSession() };
 
 // Public encryption keys of agents the current document is shared with, by WebID
 let documentRecipients = new Map();
 
 const CID_CONTEXT = 'https://www.w3.org/ns/cid/v1';
+
+// Keys predating the signing work carry no use, and everything back then was for key agreement
+function purposeOf(doc) {
+  return doc?.publicKeyJwk?.use === 'sig' ? ASSERTION : KEY_AGREEMENT;
+}
+
+function keyConfig(purpose) {
+  const keys = Config.User?.Keys;
+  return (purpose === ASSERTION ? keys?.Signing : keys?.Encryption) || {};
+}
 
 // CID 1.0 JsonWebKey document (section 2.2.3); secretKeyJwk holds the passphrase-wrapped private JWK as a flattened JWE, not a plaintext JWK
 function buildKeyDocument(publicKeyJWK, secretKeyJwe) {
@@ -111,25 +124,19 @@ async function listKeyResources(containerURL) {
   }
 }
 
-//XXX: single active key for now (members[0]); selecting by kid can come later
-async function resolveKeystoreResourceURL() {
-  if (cachedKeystoreURL) return cachedKeystoreURL;
-  const container = findKeyContainer();
-  if (!container) return null;
-  const members = await listKeyResources(container);
-  if (members.length) {
-    cachedKeystoreURL = members[0];
-    Config.User.Encryption.KeystoreURL = members[0];
-    return members[0];
-  }
-  return null;
-}
-
-// With a kid the resource URL is computed directly; without one it falls back to container discovery
-async function fetchStorageKeystore(kid) {
+// With a kid the resource URL is computed directly; without one the first stored key of that purpose is used
+async function fetchStorageKeystore(kid, purpose = KEY_AGREEMENT) {
   if (!Config.Session?.isActive) return null;
   try {
-    const url = kid ? keyResourceURL(kid) : await resolveKeystoreResourceURL();
+    if (!kid) {
+      const [doc] = await fetchStorageKeyDocuments(purpose);
+      if (doc) {
+        sessions[purpose].keystoreURL = keyResourceURL(doc.publicKeyJwk.kid);
+        keyConfig(purpose).KeystoreURL = sessions[purpose].keystoreURL;
+      }
+      return doc || null;
+    }
+    const url = keyResourceURL(kid);
     if (!url) return null;
     const response = await getResource(url, { 'Accept': 'application/ld+json' }, { noCache: true });
     const doc = await response.json();
@@ -139,7 +146,7 @@ async function fetchStorageKeystore(kid) {
   }
 }
 
-async function fetchAllStorageKeyDocuments() {
+async function fetchStorageKeyDocuments(purpose) {
   if (!Config.Session?.isActive) return [];
   const container = findKeyContainer();
   if (!container) return [];
@@ -149,17 +156,20 @@ async function fetchAllStorageKeyDocuments() {
     try {
       const response = await getResource(url, { 'Accept': 'application/ld+json' }, { noCache: true });
       const doc = await response.json();
-      if (isValidKeyDocument(doc)) docs.push(doc);
+      if (isValidKeyDocument(doc) && (!purpose || purposeOf(doc) === purpose)) docs.push(doc);
     } catch {}
   }
   return docs;
 }
 
-async function loadAllKeyDocuments() {
+// Both purposes share the key/ container and are told apart by use, so no second type index registration
+async function loadAllKeyDocuments(purpose) {
   const byKid = new Map();
-  for (const doc of await fetchAllStorageKeyDocuments()) byKid.set(doc.publicKeyJwk.kid, doc);
-  const local = await getEncryptedKeystore();
-  if (isValidKeyDocument(local) && !byKid.has(local.publicKeyJwk.kid)) byKid.set(local.publicKeyJwk.kid, local);
+  for (const doc of await fetchStorageKeyDocuments(purpose)) byKid.set(doc.publicKeyJwk.kid, doc);
+  for (const p of purpose ? [purpose] : PURPOSES) {
+    const local = await getEncryptedKeystore(p);
+    if (isValidKeyDocument(local) && !byKid.has(local.publicKeyJwk.kid)) byKid.set(local.publicKeyJwk.kid, local);
+  }
   return [...byKid.values()];
 }
 
@@ -244,8 +254,9 @@ async function saveStorageKeystore(doc, { ifNoneMatch = false } = {}) {
   const container = await ensureKeyContainer();
   await setKeystoreContainerACL(container);
 
-  cachedKeystoreURL = url;
-  Config.User.Encryption.KeystoreURL = url;
+  const purpose = purposeOf(doc);
+  sessions[purpose].keystoreURL = url;
+  keyConfig(purpose).KeystoreURL = url;
 
   const data = JSON.stringify(doc, null, 2);
   const options = ifNoneMatch ? { headers: { 'If-None-Match': '*' } } : {};
@@ -265,86 +276,97 @@ async function saveStorageKeystore(doc, { ifNoneMatch = false } = {}) {
   return url;
 }
 
-export async function createKeystore(passphrase) {
-  const { publicKey, privateKey, kid } = await generateEncryptionKeypair();
+export async function createKeystore(passphrase, purpose = KEY_AGREEMENT) {
+  const generate = purpose === ASSERTION ? generateSigningKeypair : generateEncryptionKeypair;
+  const { publicKey, privateKey, kid } = await generate();
   const publicKeyJWK = await exportPublicKeyJWK(publicKey, kid);
   const privateKeyJWK = await exportPrivateKeyJWK(privateKey, kid);
   const jwe = await wrapPrivateKeyJWK(privateKeyJWK, passphrase);
   const doc = buildKeyDocument(publicKeyJWK, jwe);
 
-  await setEncryptedKeystore(doc);
-  Config.User.Encryption.StorageSyncFailed = false;
+  await setEncryptedKeystore(doc, purpose);
+  keyConfig(purpose).StorageSyncFailed = false;
   try {
     await saveStorageKeystore(doc, { ifNoneMatch: true });
   } catch (e) {
-    Config.User.Encryption.StorageSyncFailed = true;
+    keyConfig(purpose).StorageSyncFailed = true;
     console.warn('dokieli: keystore saved locally; storage save failed', e);
   }
 
-  sessionPrivateKeys.set(kid, await importPrivateKeyJWK(privateKeyJWK));
-  sessionPublicKey = publicKey;
-  sessionPublicKeyJWK = publicKeyJWK;
-  sessionKid = kid;
+  const session = sessions[purpose];
+  session.privateKeys.set(kid, await importPrivateKeyJWK(privateKeyJWK));
+  session.publicKey = publicKey;
+  session.publicKeyJWK = publicKeyJWK;
+  session.kid = kid;
 
   return publicKeyJWK;
 }
 
-// Unlocks every key the user holds so content encrypted to a past key stays decryptable
+// Unlocks every key the user holds, of both purposes, so content encrypted to a past key stays decryptable
 export async function unlockKeystore(passphrase) {
   const docs = await loadAllKeyDocuments();
   if (!docs.length) throw new Error('No keystore found. Set up encryption first.');
 
-  const local = await getEncryptedKeystore();
-  const localKid = isValidKeyDocument(local) ? local.publicKeyJwk.kid : null;
-
-  const keys = new Map();
+  const unlocked = { [KEY_AGREEMENT]: new Map(), [ASSERTION]: new Map() };
   const docByKid = new Map();
   for (const doc of docs) {
     try {
       const kid = doc.publicKeyJwk.kid;
       const privateKeyJWK = await unwrapPrivateKeyJWK(doc.secretKeyJwk, passphrase);
-      keys.set(kid, await importPrivateKeyJWK(privateKeyJWK));
+      unlocked[purposeOf(doc)].set(kid, await importPrivateKeyJWK(privateKeyJWK));
       docByKid.set(kid, doc);
     } catch {}
   }
-  if (!keys.size) throw new Error('Unable to unlock keystore with the given passphrase.');
+  if (!docByKid.size) throw new Error('Unable to unlock keystore with the given passphrase.');
 
-  sessionPrivateKeys = keys;
-  sessionKid = (localKid && keys.has(localKid)) ? localKid : keys.keys().next().value;
-  sessionPublicKeyJWK = docByKid.get(sessionKid)?.publicKeyJwk || null;
-  sessionPublicKey = sessionPublicKeyJWK ? await importPublicKeyJWK(sessionPublicKeyJWK) : null;
+  for (const purpose of PURPOSES) {
+    const keys = unlocked[purpose];
+    if (!keys.size) continue;
 
-  const currentDoc = docByKid.get(sessionKid) || null;
-  if (!currentDoc) return;
+    const local = await getEncryptedKeystore(purpose);
+    const localKid = isValidKeyDocument(local) ? local.publicKeyJwk.kid : null;
+    const session = sessions[purpose];
 
-  // A document created while signed out has no id or controller yet
-  let cacheStale = localKid !== sessionKid;
-  if (Config.User?.IRI && !currentDoc.controller) {
-    currentDoc.controller = Config.User.IRI;
-    currentDoc.id = `${stripFragmentFromString(Config.User.IRI)}#key-${sessionKid}`;
-    cacheStale = true;
+    session.privateKeys = keys;
+    session.kid = (localKid && keys.has(localKid)) ? localKid : keys.keys().next().value;
+    session.publicKeyJWK = docByKid.get(session.kid)?.publicKeyJwk || null;
+    session.publicKey = session.publicKeyJWK ? await importPublicKeyJWK(session.publicKeyJWK) : null;
+
+    const currentDoc = docByKid.get(session.kid) || null;
+    if (!currentDoc) continue;
+
+    // A document created while signed out has no id or controller yet
+    let cacheStale = localKid !== session.kid;
+    if (Config.User?.IRI && !currentDoc.controller) {
+      currentDoc.controller = Config.User.IRI;
+      currentDoc.id = `${stripFragmentFromString(Config.User.IRI)}#key-${session.kid}`;
+      cacheStale = true;
+    }
+    if (cacheStale) await setEncryptedKeystore(currentDoc, purpose);
+
+    // Upload when the storage copy is missing (signed-out setup now signed in); key documents are immutable per kid
+    fetchStorageKeystore(session.kid, purpose)
+      .then(storage => {
+        if (!storage) return saveStorageKeystore(currentDoc, { ifNoneMatch: true });
+      })
+      .catch(e => console.warn('dokieli: keystore storage sync failed', e));
   }
-  if (cacheStale) await setEncryptedKeystore(currentDoc);
-
-  // Upload when the storage copy is missing (signed-out setup now signed in); key documents are immutable per kid
-  fetchStorageKeystore(sessionKid)
-    .then(storage => {
-      if (!storage) return saveStorageKeystore(currentDoc, { ifNoneMatch: true });
-    })
-    .catch(e => console.warn('dokieli: keystore storage sync failed', e));
 }
 
-export async function publishPublicKeyToProfile() {
-  if (!Config.Session?.isActive || !Config.User?.IRI || !sessionPublicKeyJWK) return null;
+// Key agreement keys let others encrypt to the user; assertion keys let others verify their signatures
+export async function publishPublicKeyToProfile(purpose = KEY_AGREEMENT) {
+  const session = sessions[purpose];
+  if (!Config.Session?.isActive || !Config.User?.IRI || !session.publicKeyJWK) return null;
+  const relation = purpose === ASSERTION ? Config.ns.sec.assertionMethod : Config.ns.sec.keyAgreementMethod;
   const webid = Config.User.IRI;
   const profileDoc = stripFragmentFromString(webid);
-  const keyIRI = `${profileDoc}#key-${sessionKid}`;
-  const published = Config.User.Graph?.out(Config.ns.sec.keyAgreementMethod).values || [];
+  const keyIRI = `${profileDoc}#key-${session.kid}`;
+  const published = Config.User.Graph?.out(relation).values || [];
   if (published.includes(keyIRI)) return null;
 
-  const jwk = escapeRDFLiteral(JSON.stringify(sessionPublicKeyJWK));
+  const jwk = escapeRDFLiteral(JSON.stringify(session.publicKeyJWK));
   // sec:JsonWebKey is the CID v1.0 verification method type
-  const insert = `<${webid}> <${Config.ns.sec.keyAgreementMethod.value}> <${keyIRI}> .
+  const insert = `<${webid}> <${relation.value}> <${keyIRI}> .
 <${keyIRI}> a <${Config.ns.sec.JsonWebKey.value}> ;
   <${Config.ns.sec.controller.value}> <${webid}> ;
   <${Config.ns.sec.publicKeyJwk.value}> "${jwk}"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .`;
@@ -409,46 +431,43 @@ export async function syncDocumentRecipientsFromACL(documentURL) {
 }
 
 export function lockKeystore() {
-  sessionPrivateKeys = new Map();
-  sessionPublicKey = null;
-  sessionPublicKeyJWK = null;
-  sessionKid = null;
-  cachedKeystoreURL = null;
-  storageChecked = false;
+  sessions = { [KEY_AGREEMENT]: newSession(), [ASSERTION]: newSession() };
   documentRecipients = new Map();
 }
 
-export function isUnlocked() {
-  return sessionPrivateKeys.size > 0;
+export function isUnlocked(purpose = KEY_AGREEMENT) {
+  return sessions[purpose].privateKeys.size > 0;
 }
 
-export function getSessionPrivateKey(kid) {
-  return sessionPrivateKeys.get(kid || sessionKid) || null;
+export function getSessionPrivateKey(kid, purpose = KEY_AGREEMENT) {
+  const session = sessions[purpose];
+  return session.privateKeys.get(kid || session.kid) || null;
 }
 
 // Selects the key by the JWE's kid, falling back to trying each held key
 export async function decryptWithSession(jwe) {
+  const { privateKeys } = sessions[KEY_AGREEMENT];
   for (const kid of getJWEKids(jwe)) {
-    const key = sessionPrivateKeys.get(kid);
+    const key = privateKeys.get(kid);
     if (key) return decryptContent(jwe, key);
   }
   let lastError;
-  for (const key of sessionPrivateKeys.values()) {
+  for (const key of privateKeys.values()) {
     try { return await decryptContent(jwe, key); } catch (e) { lastError = e; }
   }
   throw lastError || new Error('No unlocked key can decrypt this content.');
 }
 
-export function getSessionPublicKey() {
-  return sessionPublicKey;
+export function getSessionPublicKey(purpose = KEY_AGREEMENT) {
+  return sessions[purpose].publicKey;
 }
 
-export function getSessionPublicKeyJWK() {
-  return sessionPublicKeyJWK;
+export function getSessionPublicKeyJWK(purpose = KEY_AGREEMENT) {
+  return sessions[purpose].publicKeyJWK;
 }
 
-export function getSessionKid() {
-  return sessionKid;
+export function getSessionKid(purpose = KEY_AGREEMENT) {
+  return sessions[purpose].kid;
 }
 
 function noKeysError() {
@@ -478,8 +497,11 @@ export async function importKeyDocuments(input) {
   const known = new Set((await loadAllKeyDocuments()).map(d => d.publicKeyJwk.kid));
   const added = docs.filter(d => !known.has(d.publicKeyJwk.kid)).length;
 
-  //XXX: one document per device keystore, so the rest survive only on storage
-  await setEncryptedKeystore(docs[0]);
+  //XXX: one document per purpose on the device, so the rest survive only on storage
+  for (const purpose of PURPOSES) {
+    const doc = docs.find(d => purposeOf(d) === purpose);
+    if (doc) await setEncryptedKeystore(doc, purpose);
+  }
 
   // Returns null when there is no session or the key is already there, so count the URL
   let stored = 0;
@@ -496,11 +518,11 @@ export async function importKeyDocuments(input) {
 }
 
 // Needs the passphrase, and what it returns is unprotected
-export async function exportKeyPair(passphrase, kid) {
-  const docs = await loadAllKeyDocuments();
+export async function exportKeyPair(passphrase, kid, purpose = KEY_AGREEMENT) {
+  const docs = await loadAllKeyDocuments(purpose);
   const doc = kid
     ? docs.find(d => d.publicKeyJwk.kid === kid)
-    : docs.find(d => d.publicKeyJwk.kid === sessionKid) || docs[0];
+    : docs.find(d => d.publicKeyJwk.kid === sessions[purpose].kid) || docs[0];
   if (!doc) throw noKeysError();
 
   const privateKeyJWK = await unwrapPrivateKeyJWK(doc.secretKeyJwk, passphrase);
@@ -520,13 +542,14 @@ export async function importPrivateKeyPEM(pem, passphrase) {
 }
 
 // Probes the storage once per session so a new device gets the unlock prompt instead of setup
-export async function hasKeystore() {
-  if (isValidKeyDocument(await getEncryptedKeystore())) return true;
-  if (storageChecked || !Config.Session?.isActive) return false;
-  storageChecked = true;
-  const storage = await fetchStorageKeystore();
+export async function hasKeystore(purpose = KEY_AGREEMENT) {
+  if (isValidKeyDocument(await getEncryptedKeystore(purpose))) return true;
+  const session = sessions[purpose];
+  if (session.storageChecked || !Config.Session?.isActive) return false;
+  session.storageChecked = true;
+  const storage = await fetchStorageKeystore(null, purpose);
   if (storage) {
-    await setEncryptedKeystore(storage);
+    await setEncryptedKeystore(storage, purpose);
     return true;
   }
   return false;

--- a/src/storage.js
+++ b/src/storage.js
@@ -284,18 +284,22 @@ export function getDeviceStorageItem(key) {
   }
 }
 
-const E2EE_KEYSTORE_KEY = 'DO.Config.E2EE.Keystore';
+// Encrypted at rest whatever the key is for; keyAgreement keeps its original slot so existing devices still find their key
+const KEYSTORE_KEYS = {
+  keyAgreement: 'DO.Config.E2EE.Keystore',
+  assertion: 'DO.Config.Signing.Keystore'
+};
 
-export function getEncryptedKeystore() {
-  return get(E2EE_KEYSTORE_KEY);
+export function getEncryptedKeystore(purpose = 'keyAgreement') {
+  return get(KEYSTORE_KEYS[purpose]);
 }
 
-export function setEncryptedKeystore(keystore) {
-  return set(E2EE_KEYSTORE_KEY, keystore);
+export function setEncryptedKeystore(keystore, purpose = 'keyAgreement') {
+  return set(KEYSTORE_KEYS[purpose], keystore);
 }
 
-export function removeEncryptedKeystore() {
-  return del(E2EE_KEYSTORE_KEY);
+export function removeEncryptedKeystore(purpose = 'keyAgreement') {
+  return del(KEYSTORE_KEYS[purpose]);
 }
 
 export function updateBrowserStorageOIDC() {


### PR DESCRIPTION
Refactor only. Prepares the keystore for nanopub signing keys. 

* Key state moves to Config.User.Keys.{Encryption,Signing}
* drop the unused PodSyncFailed
* Keys carry a purpose; existing keys have no use and are treated as key agreement, so nothing changes for them; the kid is unaffected
* Adds generateSigningKeypair; nothing calls it until the signing UI on a later PR