### PR TITLE
Prefer cite-as over latest-version as the annotation target

### DIFF
--- a/src/activity.js
+++ b/src/activity.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import rdf from 'rdf-ext';
-import { createActivityObjectHTML, createActivityJSONLD, showCitations, getReferenceLabel, createNoteDataHTML, handleDeleteNote, getItemVisibility } from './doc.js';
+import { createActivityObjectHTML, createActivityJSONLD, showCitations, getReferenceLabel, createNoteDataHTML, handleDeleteNote, getItemVisibility, getPreferredTargetIRI } from './doc.js';
 import { applyMarksFromTextQuote, applyMarkFromSelector } from '@dokieli/web-annotation';
 import { Icon } from './ui/icons.js'
 import { getButtonHTML } from './ui/buttons.js'
@@ -604,6 +604,7 @@ function showActivitiesUncached(url, options = {}) {
   }
 
   var documentURL = Config.DocumentURL;
+  var preferredTargetIRI = getPreferredTargetIRI(documentURL);
 
   var documentTypes = Config.ActivitiesObjectTypes.concat(Object.keys(Config.ResourceType));
 
@@ -757,14 +758,14 @@ function showActivitiesUncached(url, options = {}) {
               if (targetPathURL == currentPathURL) {
                 o['targetInOriginalResource'] = true;
               }
-              else if (Config.Resource[documentURL].graph.out(ns.rel['latest-version']).values.length && targetPathURL == getPathURL(Config.Resource[documentURL].graph.out(ns.rel['latest-version']).values[0])) {
-                o['targetInMemento'] = true;
+              else if (preferredTargetIRI && targetPathURL == getPathURL(preferredTargetIRI)) {
+                o['targetInPreferredIRI'] = true;
               }
               else if (Config.Resource[documentURL].graph.out(ns.owl.sameAs).values.length && Config.Resource[documentURL].graph.out(ns.owl.sameAs).values[0] == targetPathURL) {
                 o['targetInSameAs'] = true;
               }
 
-              if (o['targetInOriginalResource'] || o['targetInMemento'] || o['targetInSameAs']) {
+              if (o['targetInOriginalResource'] || o['targetInPreferredIRI'] || o['targetInSameAs']) {
                 subjectsReferences.push(object);
 
                 if (options.notification) {
@@ -1373,7 +1374,7 @@ export async function showAnnotation(noteIRI, g, options) {
     var source = targetPtr.out(ns.oa.hasSource).values[0];
     // oa:hasTarget may be a blank node with oa:hasSource pointing to the document
     var targetOrSource = source || hasTarget;
-    if (targetOrSource && !(targetOrSource.startsWith(documentURL) || 'targetInMemento' in options || 'targetInSameAs' in options)){
+    if (targetOrSource && !(targetOrSource.startsWith(documentURL) || 'targetInPreferredIRI' in options || 'targetInSameAs' in options)){
       // return Promise.reject();
       return;
     }

--- a/src/doc.js
+++ b/src/doc.js
@@ -1299,6 +1299,31 @@ export function getGraphContributorsRole(g, options) {
   return contributorData;
 }
 
+//Preferred IRI to use as an annotation target for a resource (RFC 8574 cite-as, then latest-version), from Link headers and the resource's graph.
+export function getPreferredTargetIRI(documentURL) {
+  documentURL = documentURL || Config.DocumentURL;
+  var resource = Config.Resource?.[documentURL];
+  if (!resource) return undefined;
+
+  var linkHeaders = resource.headers?.linkHeaders;
+  var graph = resource.graph;
+
+  var fromLinkHeader = (rel) => {
+    if (linkHeaders?.has('rel', rel)) {
+      return sanitizeIRI(linkHeaders.rel(rel)[0].uri);
+    }
+  };
+  var fromGraph = (rel) => {
+    var values = graph?.node(rdf.namedNode(documentURL)).out(ns.rel[rel]).values;
+    return values?.length ? sanitizeIRI(values[0]) : undefined;
+  };
+
+  for (var rel of ['cite-as', 'latest-version']) {
+    var iri = fromLinkHeader(rel) || fromGraph(rel);
+    if (iri) return iri;
+  }
+}
+
 //TODO: Rename this to avoid confusion with graph.getGraphFromData
 export function getGraphData(s, options) {
   var documentURL = options['subjectURI'];
@@ -1366,6 +1391,11 @@ export function getGraphData(s, options) {
     info['profile'] = ns.mem.Memento.value;
     info['original'] = original[0];
     info['memento'] = memento[0];
+  }
+
+  var citeAs = s.out(ns.rel['cite-as']).values;
+  if (citeAs.length) {
+    info['cite-as'] = citeAs[0];
   }
 
   var latestVersion = s.out(ns.rel['latest-version']).values;

--- a/src/editor/toolbar/social/handlers.js
+++ b/src/editor/toolbar/social/handlers.js
@@ -18,7 +18,7 @@ limitations under the License.
 import { getSelectedParentElement, restoreSelection, getInboxOfClosestNodeWithSelector, createNoteData} from "../../utils/annotation.js";
 import { generateAttributeId, getDateTimeISO } from "../../../util.js"
 import { getNodeLanguage, getFormValues, createHTML } from "../../../utils/html.js";
-import { getReferenceLabel, createActivityHTML, createNoteDataHTML, getRegisteredAnnotationContainer } from "../../../doc.js";
+import { getReferenceLabel, createActivityHTML, createNoteDataHTML, getRegisteredAnnotationContainer, getPreferredTargetIRI } from "../../../doc.js";
 import { getAbsoluteIRI, stripFragmentFromString } from "../../../uri.js"
 import Config from "../../../config.js"
 import { notifyInbox, postActivity, showActivities, registerAnnotationInTypeIndex, markAnnotationTarget } from "../../../activity.js"
@@ -294,18 +294,14 @@ export function getFormActionData(action, formValues, selectionData) {
   data.refId = 'r-' + data.id;
   data.targetIRI = (data.parentNodeWithId) ? data.resourceIRI + '#' + data.parentNodeWithId.id : data.resourceIRI;
 
-  data.latestVersion = Config.Resource[data.resourceIRI].graph.out(ns.rel['latest-version']).values[0];
+  //Preferred target: cite-as, then latest-version (see https://github.com/dokieli/dokieli/issues/420)
+  data.preferredTargetIRI = getPreferredTargetIRI(data.resourceIRI);
 
-  //XXX: This needs to be revisited. Perhaps showAnnotations is not checking the latestVersion?
-  if (data.latestVersion) {
-    data.resourceIRI = data.latestVersion;
-    data.targetIRI = (data.parentNodeWithId) ? data.latestVersion + '#' + data.parentNodeWithId.id : data.latestVersion;
-    data.options.targetInMemento = true;
+  if (data.preferredTargetIRI && data.preferredTargetIRI != data.resourceIRI) {
+    data.resourceIRI = data.preferredTargetIRI;
+    data.targetIRI = (data.parentNodeWithId) ? data.preferredTargetIRI + '#' + data.parentNodeWithId.id : data.preferredTargetIRI;
+    data.options.targetInPreferredIRI = true;
   }
-
-  // console.log(latestVersion)
-  // console.log(resourceIRI)
-  // console.log(targetIRI)
 
   data.targetLanguage = getNodeLanguage(data.parentNodeWithId);
   data.selectionLanguage = getNodeLanguage(data.selectionData.selectedParentElement);


### PR DESCRIPTION
Adds `getPreferredTargetIRI`, which resolves a document's preferred IRI from the `cite-as` link relation ([RFC 8574](https://datatracker.ietf.org/doc/html/rfc8574)), falling back to `latest-version`. Each is read from the `Link` response header first, then from the document's RDFa graph via the IANA link relations namespace.

- Annotation creation now targets the preferred IRI (with the element fragment when present).
- `showActivities` matches incoming annotations against it so they are displayed on the document.
- `cite-as` is recorded in the resource info alongside `latest-version`.

Closes #420.